### PR TITLE
Fix building Proximity.cpp with Qt6 and gcc 11.2

### DIFF
--- a/src/foundation/Proximity.cpp
+++ b/src/foundation/Proximity.cpp
@@ -6,6 +6,8 @@
 #include <QLineF>
 #include <QPointF>
 
+#include <algorithm>
+
 Proximity::Proximity(const QPointF& p1, const QPointF& p2) {
   const double dx = p1.x() - p2.x();
   const double dy = p1.y() - p2.y();

--- a/src/foundation/Proximity.cpp
+++ b/src/foundation/Proximity.cpp
@@ -5,7 +5,6 @@
 
 #include <QLineF>
 #include <QPointF>
-
 #include <algorithm>
 
 Proximity::Proximity(const QPointF& p1, const QPointF& p2) {


### PR DESCRIPTION
Add <algorithm> header to the Proximity.cpp , needed by `std::min_element`.

Closes https://github.com/ScanTailor-Advanced/scantailor-libs-build/issues/7