### PR TITLE
feature #50: foreground and background zones

### DIFF
--- a/src/app/DefaultParamsDialog.cpp
+++ b/src/app/DefaultParamsDialog.cpp
@@ -48,6 +48,7 @@ DefaultParamsDialog::DefaultParamsDialog(QWidget* parent)
   thresholdMethodBox->addItem(tr("Otsu"), OTSU);
   thresholdMethodBox->addItem(tr("Sauvola"), SAUVOLA);
   thresholdMethodBox->addItem(tr("Wolf"), WOLF);
+  thresholdMethodBox->addItem(tr("Bradley"), BRADLEY);
   thresholdMethodBox->addItem(tr("EdgePlus"), EDGEPLUS);
   thresholdMethodBox->addItem(tr("BlurDiv"), BLURDIV);
   thresholdMethodBox->addItem(tr("EdgeDiv"), EDGEDIV);
@@ -665,8 +666,8 @@ std::unique_ptr<DefaultParams> DefaultParamsDialog::buildParams() const {
   blackWhiteOptions.setBinarizationMethod(binarizationMethod);
   blackWhiteOptions.setThresholdAdjustment(thresholdSlider->value());
   blackWhiteOptions.setSauvolaCoef(sauvolaCoef->value());
-  if (binarizationMethod == SAUVOLA || binarizationMethod == EDGEPLUS || binarizationMethod == BLURDIV
-      || binarizationMethod == EDGEDIV) {
+  if (binarizationMethod == SAUVOLA || binarizationMethod == BRADLEY || binarizationMethod == EDGEPLUS
+      || binarizationMethod == BLURDIV || binarizationMethod == EDGEDIV) {
     blackWhiteOptions.setWindowSize(sauvolaWindowSize->value());
   } else if (binarizationMethod == WOLF) {
     blackWhiteOptions.setWindowSize(wolfWindowSize->value());

--- a/src/core/filters/output/BlackWhiteOptions.cpp
+++ b/src/core/filters/output/BlackWhiteOptions.cpp
@@ -72,6 +72,8 @@ BinarizationMethod BlackWhiteOptions::parseBinarizationMethod(const QString& str
     return WOLF;
   } else if (str == "sauvola") {
     return SAUVOLA;
+  } else if (str == "bradley") {
+    return BRADLEY;
   } else if (str == "edgeplus") {
     return EDGEPLUS;
   } else if (str == "blurdiv") {
@@ -94,6 +96,9 @@ QString BlackWhiteOptions::formatBinarizationMethod(BinarizationMethod type) {
       break;
     case WOLF:
       str = "wolf";
+      break;
+    case BRADLEY:
+      str = "bradley";
       break;
     case EDGEPLUS:
       str = "edgeplus";

--- a/src/core/filters/output/BlackWhiteOptions.h
+++ b/src/core/filters/output/BlackWhiteOptions.h
@@ -9,7 +9,7 @@ class QDomDocument;
 class QDomElement;
 
 namespace output {
-enum BinarizationMethod { OTSU, SAUVOLA, WOLF, EDGEPLUS, BLURDIV, EDGEDIV };
+enum BinarizationMethod { OTSU, SAUVOLA, WOLF, BRADLEY, EDGEPLUS, BLURDIV, EDGEDIV };
 
 class BlackWhiteOptions {
  public:

--- a/src/core/filters/output/OptionsWidget.cpp
+++ b/src/core/filters/output/OptionsWidget.cpp
@@ -42,6 +42,7 @@ OptionsWidget::OptionsWidget(std::shared_ptr<Settings> settings, const PageSelec
   thresholdMethodBox->addItem(tr("Otsu"), OTSU);
   thresholdMethodBox->addItem(tr("Sauvola"), SAUVOLA);
   thresholdMethodBox->addItem(tr("Wolf"), WOLF);
+  thresholdMethodBox->addItem(tr("Bradley"), BRADLEY);
   thresholdMethodBox->addItem(tr("EdgePlus"), EDGEPLUS);
   thresholdMethodBox->addItem(tr("BlurDiv"), BLURDIV);
   thresholdMethodBox->addItem(tr("EdgeDiv"), EDGEDIV);
@@ -54,6 +55,8 @@ OptionsWidget::OptionsWidget(std::shared_ptr<Settings> settings, const PageSelec
   QPointer<BinarizationOptionsWidget> sauvolaBinarizationOptionsWidget
       = new SauvolaBinarizationOptionsWidget(m_settings);
   QPointer<BinarizationOptionsWidget> wolfBinarizationOptionsWidget = new WolfBinarizationOptionsWidget(m_settings);
+  QPointer<BinarizationOptionsWidget> bradleyBinarizationOptionsWidget
+      = new SauvolaBinarizationOptionsWidget(m_settings);
   QPointer<BinarizationOptionsWidget> edgeplusBinarizationOptionsWidget
       = new SauvolaBinarizationOptionsWidget(m_settings);
   QPointer<BinarizationOptionsWidget> blurdivBinarizationOptionsWidget
@@ -67,6 +70,7 @@ OptionsWidget::OptionsWidget(std::shared_ptr<Settings> settings, const PageSelec
   addBinarizationOptionsWidget(otsuBinarizationOptionsWidget);
   addBinarizationOptionsWidget(sauvolaBinarizationOptionsWidget);
   addBinarizationOptionsWidget(wolfBinarizationOptionsWidget);
+  addBinarizationOptionsWidget(bradleyBinarizationOptionsWidget);
   addBinarizationOptionsWidget(edgeplusBinarizationOptionsWidget);
   addBinarizationOptionsWidget(blurdivBinarizationOptionsWidget);
   addBinarizationOptionsWidget(edgedivBinarizationOptionsWidget);

--- a/src/core/filters/output/PictureLayerProperty.cpp
+++ b/src/core/filters/output/PictureLayerProperty.cpp
@@ -33,13 +33,17 @@ std::shared_ptr<Property> PictureLayerProperty::construct(const QDomElement& el)
 
 PictureLayerProperty::Layer PictureLayerProperty::layerFromString(const QString& str) {
   if (str == "eraser1") {
-    return ERASER1;
+    return ZONEERASER1;
   } else if (str == "painter2") {
-    return PAINTER2;
+    return ZONEPAINTER2;
   } else if (str == "eraser3") {
-    return ERASER3;
+    return ZONEERASER3;
+  } else if (str == "foreground") {
+    return ZONEFG;
+  } else if (str == "background") {
+    return ZONEBG;
   } else {
-    return NO_OP;
+    return ZONENOOP;
   }
 }
 
@@ -47,14 +51,20 @@ QString PictureLayerProperty::layerToString(Layer layer) {
   QString str;
 
   switch (layer) {
-    case ERASER1:
+    case ZONEERASER1:
       str = "eraser1";
       break;
-    case PAINTER2:
+    case ZONEPAINTER2:
       str = "painter2";
       break;
-    case ERASER3:
+    case ZONEERASER3:
       str = "eraser3";
+      break;
+    case ZONEFG:
+      str = "foreground";
+      break;
+    case ZONEBG:
+      str = "background";
       break;
     default:
       str = "";

--- a/src/core/filters/output/PictureLayerProperty.h
+++ b/src/core/filters/output/PictureLayerProperty.h
@@ -16,9 +16,9 @@ class QString;
 namespace output {
 class PictureLayerProperty : public Property {
  public:
-  enum Layer { NO_OP, ERASER1, PAINTER2, ERASER3 };
+  enum Layer { ZONENOOP, ZONEERASER1, ZONEPAINTER2, ZONEERASER3, ZONEFG, ZONEBG };
 
-  explicit PictureLayerProperty(Layer layer = NO_OP);
+  explicit PictureLayerProperty(Layer layer = ZONENOOP);
 
   explicit PictureLayerProperty(const QDomElement& el);
 

--- a/src/core/filters/output/PictureZoneEditor.cpp
+++ b/src/core/filters/output/PictureZoneEditor.cpp
@@ -213,29 +213,47 @@ void PictureZoneEditor::paintOverPictureMask(QPainter& painter) {
 
   using PLP = PictureLayerProperty;
 
+  // Pass 1: ZONEERASER1
   painter.setCompositionMode(QPainter::CompositionMode_Clear);
 
-  // First pass: ERASER1
   for (const EditableZoneSet::Zone& zone : zones()) {
-    if (zone.properties()->locateOrDefault<PLP>()->layer() == PLP::ERASER1) {
+    if (zone.properties()->locateOrDefault<PLP>()->layer() == PLP::ZONEERASER1) {
       painter.drawPolygon(zone.spline()->toPolygon(), Qt::WindingFill);
     }
   }
 
+  // Pass 2: ZONEFG
   painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
 
-  // Second pass: PAINTER2
   for (const EditableZoneSet::Zone& zone : zones()) {
-    if (zone.properties()->locateOrDefault<PLP>()->layer() == PLP::PAINTER2) {
+    if (zone.properties()->locateOrDefault<PLP>()->layer() == PLP::ZONEFG) {
       painter.drawPolygon(zone.spline()->toPolygon(), Qt::WindingFill);
     }
   }
 
+  // Pass 3: ZONEBG
+  painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
+
+  for (const EditableZoneSet::Zone& zone : zones()) {
+    if (zone.properties()->locateOrDefault<PLP>()->layer() == PLP::ZONEBG) {
+      painter.drawPolygon(zone.spline()->toPolygon(), Qt::WindingFill);
+    }
+  }
+
+  // Pass 4: ZONEPAINTER2
+  painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
+
+  for (const EditableZoneSet::Zone& zone : zones()) {
+    if (zone.properties()->locateOrDefault<PLP>()->layer() == PLP::ZONEPAINTER2) {
+      painter.drawPolygon(zone.spline()->toPolygon(), Qt::WindingFill);
+    }
+  }
+
+  // Pass 5: ZONEERASER3
   painter.setCompositionMode(QPainter::CompositionMode_Clear);
 
-  // Third pass: ERASER3
   for (const EditableZoneSet::Zone& zone : zones()) {
-    if (zone.properties()->locateOrDefault<PLP>()->layer() == PLP::ERASER3) {
+    if (zone.properties()->locateOrDefault<PLP>()->layer() == PLP::ZONEERASER3) {
       painter.drawPolygon(zone.spline()->toPolygon(), Qt::WindingFill);
     }
   }

--- a/src/core/filters/output/PictureZonePropDialog.cpp
+++ b/src/core/filters/output/PictureZonePropDialog.cpp
@@ -13,34 +13,46 @@ PictureZonePropDialog::PictureZonePropDialog(std::shared_ptr<PropertySet> props,
   ui.setupUi(this);
 
   switch (m_props->locateOrDefault<PictureLayerProperty>()->layer()) {
-    case PictureLayerProperty::NO_OP:
+    case PictureLayerProperty::ZONENOOP:
       break;
-    case PictureLayerProperty::ERASER1:
-      ui.eraser1->setChecked(true);
+    case PictureLayerProperty::ZONEERASER1:
+      ui.zoneeraser1->setChecked(true);
       break;
-    case PictureLayerProperty::PAINTER2:
-      ui.painter2->setChecked(true);
+    case PictureLayerProperty::ZONEPAINTER2:
+      ui.zonepainter2->setChecked(true);
       break;
-    case PictureLayerProperty::ERASER3:
-      ui.eraser3->setChecked(true);
+    case PictureLayerProperty::ZONEERASER3:
+      ui.zoneeraser3->setChecked(true);
+      break;
+    case PictureLayerProperty::ZONEFG:
+      ui.zoneforeground->setChecked(true);
+      break;
+    case PictureLayerProperty::ZONEBG:
+      ui.zonebackground->setChecked(true);
       break;
   }
 
-  connect(ui.eraser1, SIGNAL(toggled(bool)), SLOT(itemToggled(bool)));
-  connect(ui.painter2, SIGNAL(toggled(bool)), SLOT(itemToggled(bool)));
-  connect(ui.eraser3, SIGNAL(toggled(bool)), SLOT(itemToggled(bool)));
+  connect(ui.zoneeraser1, SIGNAL(toggled(bool)), SLOT(itemToggled(bool)));
+  connect(ui.zonepainter2, SIGNAL(toggled(bool)), SLOT(itemToggled(bool)));
+  connect(ui.zoneeraser3, SIGNAL(toggled(bool)), SLOT(itemToggled(bool)));
+  connect(ui.zoneforeground, SIGNAL(toggled(bool)), SLOT(itemToggled(bool)));
+  connect(ui.zonebackground, SIGNAL(toggled(bool)), SLOT(itemToggled(bool)));
 }
 
 void PictureZonePropDialog::itemToggled(bool selected) {
-  PictureLayerProperty::Layer layer = PictureLayerProperty::NO_OP;
+  PictureLayerProperty::Layer layer = PictureLayerProperty::ZONENOOP;
 
   QObject* const obj = sender();
-  if (obj == ui.eraser1) {
-    layer = PictureLayerProperty::ERASER1;
-  } else if (obj == ui.painter2) {
-    layer = PictureLayerProperty::PAINTER2;
-  } else if (obj == ui.eraser3) {
-    layer = PictureLayerProperty::ERASER3;
+  if (obj == ui.zoneeraser1) {
+    layer = PictureLayerProperty::ZONEERASER1;
+  } else if (obj == ui.zonepainter2) {
+    layer = PictureLayerProperty::ZONEPAINTER2;
+  } else if (obj == ui.zoneeraser3) {
+    layer = PictureLayerProperty::ZONEERASER3;
+  } else if (obj == ui.zoneforeground) {
+    layer = PictureLayerProperty::ZONEFG;
+  } else if (obj == ui.zonebackground) {
+    layer = PictureLayerProperty::ZONEBG;
   }
 
   m_props->locateOrCreate<PictureLayerProperty>()->setLayer(layer);

--- a/src/core/filters/output/PictureZonePropDialog.ui
+++ b/src/core/filters/output/PictureZonePropDialog.ui
@@ -13,25 +13,39 @@
   <property name="windowTitle">
    <string>Zone Properties</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QVBoxLayout" name="zoneverticalLayout">
    <item>
-    <widget class="QRadioButton" name="eraser3">
+    <widget class="QRadioButton" name="zoneeraser3">
      <property name="text">
       <string>Subtract from all layers</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QRadioButton" name="painter2">
+    <widget class="QRadioButton" name="zonepainter2">
      <property name="text">
       <string>Add to auto layer</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QRadioButton" name="eraser1">
+    <widget class="QRadioButton" name="zoneeraser1">
      <property name="text">
       <string>Subtract from auto layer</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="zoneforeground">
+     <property name="text">
+      <string>Add to foreground</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="zonebackground">
+     <property name="text">
+      <string>Add to background</string>
      </property>
     </widget>
    </item>

--- a/src/core/filters/output/Settings.cpp
+++ b/src/core/filters/output/Settings.cpp
@@ -275,7 +275,7 @@ void Settings::setDefaultFillZoneProperties(const PropertySet& props) {
 
 PropertySet Settings::initialPictureZoneProps() {
   PropertySet props;
-  props.locateOrCreate<PictureLayerProperty>()->setLayer(PictureLayerProperty::PAINTER2);
+  props.locateOrCreate<PictureLayerProperty>()->setLayer(PictureLayerProperty::ZONEPAINTER2);
   return props;
 }
 

--- a/src/imageproc/Binarize.h
+++ b/src/imageproc/Binarize.h
@@ -62,6 +62,14 @@ BinaryImage binarizeWolf(const QImage& src,
                          double delta = 0.0);
 
 /**
+ * \brief Image binarization using Bradley's adaptive thresholding method.
+ *
+ * Derek Bradley, Gerhard Roth. 2005. "Adaptive Thresholding Using the Integral Image".
+ * http://www.scs.carleton.ca/~roth/iit-publications-iti/docs/gerh-50002.pdf
+ */
+BinaryImage binarizeBradley(const QImage& src, QSize windowSize, double k = 0.34, double delta = 0.0);
+
+/**
  * \brief Image binarization using EdgeDiv (EdgePlus & BlurDiv) local/global thresholding method.
  *
  * EdgeDiv, zvezdochiot 2023. "Adaptive/global document image binarization".


### PR DESCRIPTION
Hi @vigri and @lightsilverberryfox .

Added the ability to add color zones by mask: "Add to foreground" and "Add to background".

How it works:

| 1 / 4 | 2 / 5 | 3 / 6 |
| --- | --- | --- |
| Origin | BW mode | Mixed: zone "Add to foreground" |
| ![screen-00-orig](https://github.com/ScanTailor-Advanced/scantailor-advanced/assets/12370082/af7aae6b-22f3-46d6-9ff4-27a91d619b0e) | ![screen-01-bw](https://github.com/ScanTailor-Advanced/scantailor-advanced/assets/12370082/d8f157a0-1c0d-49ee-993f-f53b6e4ec9a8) | ![screen-02-zone](https://github.com/ScanTailor-Advanced/scantailor-advanced/assets/12370082/f60bf66a-bf6c-4830-8215-871b025606e5) |
| Out | deWarping: Auto | Out dewarping |
| ![screen-03-out](https://github.com/ScanTailor-Advanced/scantailor-advanced/assets/12370082/174aece4-8516-436c-bb64-4394d67d80f9) | ![screen-04-dewarp](https://github.com/ScanTailor-Advanced/scantailor-advanced/assets/12370082/c60d52ff-5234-4373-a31e-d1b8c1f4ae31) | ![screen-05-dewarp-out](https://github.com/ScanTailor-Advanced/scantailor-advanced/assets/12370082/b8486ae2-5889-44e8-95ea-d259649d01c0) |

See https://github.com/ScanTailor-Advanced/scantailor-advanced/issues/50

Good luck.

PS: Zone overlay:
* ZONEBG + ZONEFG == ZONEPAINTER2.
* ZONEBG + ZONEBG == ZONEBG. (repeat)
* ZONEFG + ZONEFG == ZONEFG. (repeat)
