### PR TITLE
This lets scantailor-advanced for Qt6 compile with MSVC.

### DIFF
--- a/src/core/Utils.h
+++ b/src/core/Utils.h
@@ -5,6 +5,7 @@
 #define SCANTAILOR_CORE_UTILS_H_
 
 #include <QString>
+#include <QObject>
 #include <map>
 #include <unordered_map>
 


### PR DESCRIPTION
When you're running Windows and try to build scantailor-advanced for Qt 6 with MSVC, compiling will stop at the following file with error

`src\core\Utils.h(97): error C2027: use of undefined type 'QObject'`

Adding line 8:

`#include <QObject>`

to this file will allow compiling to finish successfully.