### PR TITLE
Deskew: add oblique (manual + auto) — Implements #53

### DIFF
--- a/src/core/filters/deskew/CMakeLists.txt
+++ b/src/core/filters/deskew/CMakeLists.txt
@@ -13,6 +13,7 @@ set(sources
     Task.cpp Task.h
     CacheDrivenTask.cpp CacheDrivenTask.h
     Dependencies.cpp Dependencies.h
+    ObliqueFinder.cpp ObliqueFinder.h
     Params.cpp Params.h
     ApplyDialog.cpp ApplyDialog.h
     Utils.cpp Utils.h)

--- a/src/core/filters/deskew/ImageView.cpp
+++ b/src/core/filters/deskew/ImageView.cpp
@@ -18,6 +18,7 @@
 namespace deskew {
 const double ImageView::m_maxRotationDeg = 45.0;
 const double ImageView::m_maxRotationSin = std::sin(m_maxRotationDeg * constants::DEG2RAD);
+const double ImageView::m_maxObliqueDeg = 5.0;
 const int ImageView::m_cellSize = 20;
 
 ImageView::ImageView(const QImage& image, const QImage& downscaledImage, const ImageTransformation& xform)
@@ -30,15 +31,16 @@ ImageView::ImageView(const QImage& image, const QImage& downscaledImage, const I
 
   interactionState().setDefaultStatusTip(tr("Use Ctrl+Wheel to rotate or Ctrl+Shift+Wheel for finer rotation."));
 
-  const QString tip(tr("Drag this handle to rotate the image."));
+  const QString rotationTip(tr("Drag this handle to rotate the image."));
+  const QString obliqueTip(tr("Drag this handle to adjust oblique (shear)."));
   const double hitRadius = std::max<double>(0.5 * m_handlePixmap.width(), 15.0);
-  for (int i = 0; i < 2; ++i) {
+  for (int i = 0; i < 4; ++i) {
     m_handles[i].setHitRadius(hitRadius);
     m_handles[i].setPositionCallback(boost::bind(&ImageView::handlePosition, this, i));
     m_handles[i].setMoveRequestCallback(boost::bind(&ImageView::handleMoveRequest, this, i, boost::placeholders::_1));
     m_handles[i].setDragFinishedCallback(boost::bind(&ImageView::dragFinished, this));
 
-    m_handleInteractors[i].setProximityStatusTip(tip);
+    m_handleInteractors[i].setProximityStatusTip(i < 2 ? rotationTip : obliqueTip);
     m_handleInteractors[i].setObject(&m_handles[i]);
 
     makeLastFollower(m_handleInteractors[i]);
@@ -82,6 +84,15 @@ void ImageView::manualDeskewAngleSetExternally(const double degrees) {
   }
 
   m_xform.setPostRotation(degrees);
+  updateTransform(ImagePresentation(m_xform.transform(), m_xform.resultingPreCropArea()));
+}
+
+void ImageView::manualObliqueAngleSetExternally(const double degrees) {
+  if (m_xform.postOblique() == degrees) {
+    return;
+  }
+
+  m_xform.setPostOblique(degrees);
   updateTransform(ImagePresentation(m_xform.transform(), m_xform.resultingPreCropArea()));
 }
 
@@ -137,6 +148,17 @@ void ImageView::onPaint(QPainter& painter, const InteractionState& interaction) 
   painter.drawPixmap(rect.topLeft(), m_handlePixmap);
   rect.moveCenter(handles.second);
   painter.drawPixmap(rect.topLeft(), m_handlePixmap);
+
+  // Vertical arc and handles for oblique (shear).
+  const QRectF obliqueArcSquare(getObliqueArcSquare());
+  painter.drawArc(obliqueArcSquare, qRound(16 * (90 - m_maxObliqueDeg)), qRound(16 * 2 * m_maxObliqueDeg));
+  painter.drawArc(obliqueArcSquare, qRound(16 * (270 - m_maxObliqueDeg)), qRound(16 * 2 * m_maxObliqueDeg));
+
+  const std::pair<QPointF, QPointF> obliqueHandles(getObliqueHandles(obliqueArcSquare));
+  rect.moveCenter(obliqueHandles.first);
+  painter.drawPixmap(rect.topLeft(), m_handlePixmap);
+  rect.moveCenter(obliqueHandles.second);
+  painter.drawPixmap(rect.topLeft(), m_handlePixmap);
 }  // ImageView::onPaint
 
 void ImageView::onWheelEvent(QWheelEvent* event, InteractionState& interaction) {
@@ -168,37 +190,60 @@ void ImageView::onWheelEvent(QWheelEvent* event, InteractionState& interaction) 
 }  // ImageView::onWheelEvent
 
 QPointF ImageView::handlePosition(int idx) const {
-  const std::pair<QPointF, QPointF> handles(getRotationHandles(getRotationArcSquare()));
-  if (idx == 0) {
-    return handles.first;
+  if (idx < 2) {
+    const std::pair<QPointF, QPointF> handles(getRotationHandles(getRotationArcSquare()));
+    return idx == 0 ? handles.first : handles.second;
   } else {
-    return handles.second;
+    const std::pair<QPointF, QPointF> handles(getObliqueHandles(getObliqueArcSquare()));
+    return idx == 2 ? handles.first : handles.second;
   }
 }
 
 void ImageView::handleMoveRequest(int idx, const QPointF& pos) {
-  const QRectF arcSquare(getRotationArcSquare());
-  const double arcRadius = 0.5 * arcSquare.width();
-  const double absY = pos.y();
-  double relY = absY - arcSquare.center().y();
-  relY = qBound(-arcRadius, relY, arcRadius);
+  if (idx < 2) {
+    const QRectF arcSquare(getRotationArcSquare());
+    const double arcRadius = 0.5 * arcSquare.width();
+    const double absY = pos.y();
+    double relY = absY - arcSquare.center().y();
+    relY = qBound(-arcRadius, relY, arcRadius);
 
-  double angleRad = std::asin(relY / arcRadius);
-  if (idx == 0) {
-    angleRad = -angleRad;
-  }
-  double angleDeg = angleRad * constants::RAD2DEG;
-  angleDeg = qBound(-m_maxRotationDeg, angleDeg, m_maxRotationDeg);
-  if (angleDeg == m_xform.postRotation()) {
-    return;
-  }
+    double angleRad = std::asin(relY / arcRadius);
+    if (idx == 0) {
+      angleRad = -angleRad;
+    }
+    double angleDeg = angleRad * constants::RAD2DEG;
+    angleDeg = qBound(-m_maxRotationDeg, angleDeg, m_maxRotationDeg);
+    if (angleDeg == m_xform.postRotation()) {
+      return;
+    }
 
-  m_xform.setPostRotation(angleDeg);
-  updateTransformPreservingScale(ImagePresentation(m_xform.transform(), m_xform.resultingPreCropArea()));
+    m_xform.setPostRotation(angleDeg);
+    updateTransformPreservingScale(ImagePresentation(m_xform.transform(), m_xform.resultingPreCropArea()));
+  } else {
+    const QRectF arcSquare(getObliqueArcSquare());
+    const double arcRadius = 0.5 * arcSquare.height();
+    const double absX = pos.x();
+    double relX = absX - arcSquare.center().x();
+    relX = qBound(-arcRadius, relX, arcRadius);
+
+    double angleRad = std::asin(relX / arcRadius);
+    if (idx == 3) {
+      angleRad = -angleRad;  // bottom handle: right drag => negative oblique
+    }
+    double angleDeg = angleRad * constants::RAD2DEG;
+    angleDeg = qBound(-m_maxObliqueDeg, angleDeg, m_maxObliqueDeg);
+    if (angleDeg == m_xform.postOblique()) {
+      return;
+    }
+
+    m_xform.setPostOblique(angleDeg);
+    updateTransformPreservingScale(ImagePresentation(m_xform.transform(), m_xform.resultingPreCropArea()));
+  }
 }
 
 void ImageView::dragFinished() {
   emit manualDeskewAngleSet(m_xform.postRotation());
+  emit manualObliqueAngleSet(m_xform.postOblique());
 }
 
 /**
@@ -243,5 +288,38 @@ std::pair<QPointF, QPointF> ImageView::getRotationHandles(const QRectF& arcSquar
   QPointF rightHandle(rotCos * arcRadius, rotSin * arcRadius);
   rightHandle += arcCenter;
   return std::make_pair(leftHandle, rightHandle);
+}
+
+QRectF ImageView::getObliqueArcSquare() const {
+  const double hMargin
+      = 0.5 * m_handlePixmap.width()
+        + verticalScrollBar()->style()->pixelMetric(QStyle::PM_ScrollBarExtent, nullptr, verticalScrollBar());
+  const double vMargin
+      = 0.5 * m_handlePixmap.height()
+        + horizontalScrollBar()->style()->pixelMetric(QStyle::PM_ScrollBarExtent, nullptr, horizontalScrollBar());
+
+  QRectF reducedScreenRect(maxViewportRect());
+  reducedScreenRect.adjust(hMargin, vMargin, -hMargin, -vMargin);
+
+  const double obliqueSin = std::sin(m_maxObliqueDeg * constants::DEG2RAD);
+  QSizeF arcSize(obliqueSin, 1.0);
+  arcSize.scale(reducedScreenRect.size(), Qt::KeepAspectRatio);
+  arcSize.setWidth(arcSize.height());
+
+  QRectF arcSquare(QPointF(0, 0), arcSize);
+  arcSquare.moveRight(reducedScreenRect.right());
+  arcSquare.moveCenter(QPointF(arcSquare.center().x(), reducedScreenRect.center().y()));
+  return arcSquare;
+}
+
+std::pair<QPointF, QPointF> ImageView::getObliqueHandles(const QRectF& arcSquare) const {
+  const double obliqueRad = m_xform.postOblique() * constants::DEG2RAD;
+  const double oblSin = std::sin(obliqueRad);
+  const double oblCos = std::cos(obliqueRad);
+  const double arcRadius = 0.5 * arcSquare.height();
+  const QPointF arcCenter(arcSquare.center());
+  QPointF topHandle(arcCenter.x() + oblSin * arcRadius, arcCenter.y() - oblCos * arcRadius);
+  QPointF bottomHandle(arcCenter.x() - oblSin * arcRadius, arcCenter.y() + oblCos * arcRadius);
+  return std::make_pair(topHandle, bottomHandle);
 }
 }  // namespace deskew

--- a/src/core/filters/deskew/ImageView.h
+++ b/src/core/filters/deskew/ImageView.h
@@ -33,9 +33,13 @@ class ImageView : public ImageViewBase, private InteractionHandler {
 
   void manualDeskewAngleSet(double degrees);
 
+  void manualObliqueAngleSet(double degrees);
+
  public slots:
 
   void manualDeskewAngleSetExternally(double degrees);
+
+  void manualObliqueAngleSetExternally(double degrees);
 
   void doRotateLeft();
 
@@ -61,13 +65,18 @@ class ImageView : public ImageViewBase, private InteractionHandler {
 
   std::pair<QPointF, QPointF> getRotationHandles(const QRectF& arcSquare) const;
 
+  QRectF getObliqueArcSquare() const;
+
+  std::pair<QPointF, QPointF> getObliqueHandles(const QRectF& arcSquare) const;
+
   static const int m_cellSize;
   static const double m_maxRotationDeg;
   static const double m_maxRotationSin;
+  static const double m_maxObliqueDeg;
 
   QPixmap m_handlePixmap;
-  DraggablePoint m_handles[2];
-  ObjectDragHandler m_handleInteractors[2];
+  DraggablePoint m_handles[4];  // 0,1: rotation; 2,3: oblique
+  ObjectDragHandler m_handleInteractors[4];
   DragHandler m_dragHandler;
   ZoomHandler m_zoomHandler;
   ImageTransformation m_xform;

--- a/src/core/filters/deskew/ObliqueFinder.cpp
+++ b/src/core/filters/deskew/ObliqueFinder.cpp
@@ -58,12 +58,10 @@ std::optional<double> findObliqueDegrees(const BinaryImage& mask,
   const Skew s1 = skewFinder.findSkew(mask);
   const Skew s2 = skewFinder.findSkew(rotated);
 
-  // Only require confidence on the main skew (s1); s2 on the rotated sausage mask may be noisier (review #110).
-  if (s1.confidence() < Skew::GOOD_CONFIDENCE) {
-    return std::nullopt;
-  }
-
-  double oblique = s1.angle() - s2.angle();
+  // Weight angles by confidence so low-confidence skew contributes less (PR #110, zvezdochiot).
+  const double angleHor = s1.angle() * s1.confidence() / (s1.confidence() + 1.0);
+  const double angleVert = s2.angle() * s2.confidence() / (s2.confidence() + 1.0);
+  double oblique = angleVert - angleHor;
   oblique = std::max(-maxObliqueDeg, std::min(maxObliqueDeg, oblique));
   return oblique;
 }

--- a/src/core/filters/deskew/ObliqueFinder.cpp
+++ b/src/core/filters/deskew/ObliqueFinder.cpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2019  Joseph Artsimovich <joseph.artsimovich@gmail.com>, 4lex4 <4lex49@zoho.com>
 // Use of this source code is governed by the GNU GPL v3 license that can be found in the LICENSE file.
+// Auto oblique: Zvezdochiot; dev branch implements as requested (see ObliqueFinder.h).
 
 #include "ObliqueFinder.h"
 

--- a/src/core/filters/deskew/ObliqueFinder.cpp
+++ b/src/core/filters/deskew/ObliqueFinder.cpp
@@ -7,8 +7,8 @@
 #include <algorithm>
 #include <cmath>
 
-#include <BinaryImage.h>
 #include <BWColor.h>
+#include <BinaryImage.h>
 #include <SkewFinder.h>
 #include <imageproc/OrthogonalRotation.h>
 
@@ -45,9 +45,7 @@ BinaryImage buildSausageMask(const BinaryImage& image) {
   return result;
 }
 
-std::optional<double> findObliqueDegrees(const BinaryImage& mask,
-                                         SkewFinder& skewFinder,
-                                         double maxObliqueDeg) {
+std::optional<double> findObliqueDegrees(const BinaryImage& mask, SkewFinder& skewFinder, double maxObliqueDeg) {
   if (mask.isNull()) {
     return std::nullopt;
   }

--- a/src/core/filters/deskew/ObliqueFinder.cpp
+++ b/src/core/filters/deskew/ObliqueFinder.cpp
@@ -58,7 +58,8 @@ std::optional<double> findObliqueDegrees(const BinaryImage& mask,
   const Skew s1 = skewFinder.findSkew(mask);
   const Skew s2 = skewFinder.findSkew(rotated);
 
-  if (s1.confidence() < Skew::GOOD_CONFIDENCE || s2.confidence() < Skew::GOOD_CONFIDENCE) {
+  // Only require confidence on the main skew (s1); s2 on the rotated sausage mask may be noisier (review #110).
+  if (s1.confidence() < Skew::GOOD_CONFIDENCE) {
     return std::nullopt;
   }
 

--- a/src/core/filters/deskew/ObliqueFinder.cpp
+++ b/src/core/filters/deskew/ObliqueFinder.cpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2019  Joseph Artsimovich <joseph.artsimovich@gmail.com>, 4lex4 <4lex49@zoho.com>
+// Use of this source code is governed by the GNU GPL v3 license that can be found in the LICENSE file.
+
+#include "ObliqueFinder.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <BinaryImage.h>
+#include <BWColor.h>
+#include <SkewFinder.h>
+#include <imageproc/OrthogonalRotation.h>
+
+namespace deskew {
+
+using namespace imageproc;
+
+BinaryImage buildSausageMask(const BinaryImage& image) {
+  if (image.isNull()) {
+    return BinaryImage();
+  }
+  const int w = image.width();
+  const int h = image.height();
+  BinaryImage result(w, h, WHITE);
+
+  for (int y = 0; y < h; ++y) {
+    int count = 0;
+    int64_t sumX = 0;
+    for (int x = 0; x < w; ++x) {
+      if (image.getPixel(x, y) == BLACK) {
+        ++count;
+        sumX += x;
+      }
+    }
+    if (count > 0) {
+      const double center = static_cast<double>(sumX) / count;
+      const int left = std::max(0, static_cast<int>(std::floor(center - count / 2.0)));
+      const int len = std::min(count, w - left);
+      if (len > 0) {
+        result.fill(QRect(left, y, len, 1), BLACK);
+      }
+    }
+  }
+  return result;
+}
+
+std::optional<double> findObliqueDegrees(const BinaryImage& mask,
+                                         SkewFinder& skewFinder,
+                                         double maxObliqueDeg) {
+  if (mask.isNull()) {
+    return std::nullopt;
+  }
+
+  const BinaryImage sausage = buildSausageMask(mask);
+  const BinaryImage rotated = orthogonalRotation(sausage, 90);
+
+  const Skew s1 = skewFinder.findSkew(mask);
+  const Skew s2 = skewFinder.findSkew(rotated);
+
+  if (s1.confidence() < Skew::GOOD_CONFIDENCE || s2.confidence() < Skew::GOOD_CONFIDENCE) {
+    return std::nullopt;
+  }
+
+  double oblique = s1.angle() - s2.angle();
+  oblique = std::max(-maxObliqueDeg, std::min(maxObliqueDeg, oblique));
+  return oblique;
+}
+
+}  // namespace deskew

--- a/src/core/filters/deskew/ObliqueFinder.h
+++ b/src/core/filters/deskew/ObliqueFinder.h
@@ -1,0 +1,38 @@
+// Copyright (C) 2019  Joseph Artsimovich <joseph.artsimovich@gmail.com>, 4lex4 <4lex49@zoho.com>
+// Use of this source code is governed by the GNU GPL v3 license that can be found in the LICENSE file.
+
+#ifndef SCANTAILOR_CORE_OBLIQUEFINDER_H_
+#define SCANTAILOR_CORE_OBLIQUEFINDER_H_
+
+#include <optional>
+
+namespace imageproc {
+class BinaryImage;
+class SkewFinder;
+}  // namespace imageproc
+
+namespace deskew {
+
+/**
+ * \brief Build a "sausage" mask from a binary image.
+ *
+ * For each row, black pixels are replaced by a horizontal strip of the same
+ * length centered at their average x position. Used to estimate oblique (shear)
+ * by comparing skew of the normal mask vs the same mask rotated 90°.
+ */
+imageproc::BinaryImage buildSausageMask(const imageproc::BinaryImage& image);
+
+/**
+ * \brief Estimate oblique angle in degrees using sausage-mask and skew difference.
+ *
+ * Builds sausage mask, rotates it 90°, runs SkewFinder on original and rotated.
+ * Oblique = skew(original) - skew(rotated), clamped to ±maxObliqueDeg.
+ * Returns std::nullopt if either skew has low confidence or result is invalid.
+ */
+std::optional<double> findObliqueDegrees(const imageproc::BinaryImage& mask,
+                                         imageproc::SkewFinder& skewFinder,
+                                         double maxObliqueDeg = 5.0);
+
+}  // namespace deskew
+
+#endif

--- a/src/core/filters/deskew/ObliqueFinder.h
+++ b/src/core/filters/deskew/ObliqueFinder.h
@@ -1,5 +1,8 @@
 // Copyright (C) 2019  Joseph Artsimovich <joseph.artsimovich@gmail.com>, 4lex4 <4lex49@zoho.com>
 // Use of this source code is governed by the GNU GPL v3 license that can be found in the LICENSE file.
+//
+// Auto oblique (Issue #2): algorithm requested by Zvezdochiot; in the dev branch this is implemented
+// as requested (sausage mask, 90° rotation, skew difference, ±5° limit).
 
 #ifndef SCANTAILOR_CORE_OBLIQUEFINDER_H_
 #define SCANTAILOR_CORE_OBLIQUEFINDER_H_

--- a/src/core/filters/deskew/ObliqueFinder.h
+++ b/src/core/filters/deskew/ObliqueFinder.h
@@ -28,9 +28,10 @@ imageproc::BinaryImage buildSausageMask(const imageproc::BinaryImage& image);
 /**
  * \brief Estimate oblique angle in degrees using sausage-mask and skew difference.
  *
+ * For best results the mask should be from a deskewed (horizontal) image (see PR #110).
  * Builds sausage mask, rotates it 90°, runs SkewFinder on original and rotated.
  * Oblique = skew(original) - skew(rotated), clamped to ±maxObliqueDeg.
- * Returns std::nullopt if either skew has low confidence or result is invalid.
+ * Returns std::nullopt if skew has low confidence or result is invalid.
  */
 std::optional<double> findObliqueDegrees(const imageproc::BinaryImage& mask,
                                          imageproc::SkewFinder& skewFinder,

--- a/src/core/filters/deskew/OptionsWidget.cpp
+++ b/src/core/filters/deskew/OptionsWidget.cpp
@@ -76,6 +76,18 @@ void OptionsWidget::manualDeskewAngleSetExternally(const double degrees) {
   emit invalidateThumbnail(m_pageId);
 }
 
+void OptionsWidget::manualObliqueAngleSetExternally(const double degrees) {
+  auto block = m_connectionManager.getScopedBlock();
+
+  m_uiData.setEffectiveObliqueAngle(degrees);
+  m_uiData.setMode(MODE_MANUAL);
+  updateModeIndication(MODE_MANUAL);
+  obliqueSpinBox->setValue(degrees);
+  commitCurrentParams();
+
+  emit invalidateThumbnail(m_pageId);
+}
+
 void OptionsWidget::preUpdateUI(const PageId& pageId) {
   auto block = m_connectionManager.getScopedBlock();
 
@@ -192,6 +204,7 @@ void OptionsWidget::obliqueSpinBoxValueChanged(double value) {
     updateModeIndication(MODE_MANUAL);
   }
   commitCurrentParams();
+  emit manualObliqueAngleSet(value);
   emit invalidateThumbnail(m_pageId);
 }
 

--- a/src/core/filters/deskew/OptionsWidget.h
+++ b/src/core/filters/deskew/OptionsWidget.h
@@ -62,9 +62,13 @@ class OptionsWidget : public FilterOptionsWidget, private Ui::OptionsWidget {
 
   void manualDeskewAngleSet(double degrees);
 
+  void manualObliqueAngleSet(double degrees);
+
  public slots:
 
   void manualDeskewAngleSetExternally(double degrees);
+
+  void manualObliqueAngleSetExternally(double degrees);
 
  public:
   void preUpdateUI(const PageId& pageId);

--- a/src/core/filters/deskew/Params.cpp
+++ b/src/core/filters/deskew/Params.cpp
@@ -1,5 +1,6 @@
 // Copyright (C) 2019  Joseph Artsimovich <joseph.artsimovich@gmail.com>, 4lex4 <4lex49@zoho.com>
 // Use of this source code is governed by the GNU GPLv3 license that can be found in the LICENSE file.
+// Split Params: Zvezdochiot; dev branch implements as requested (see Params.h).
 
 #include "Params.h"
 

--- a/src/core/filters/deskew/Params.cpp
+++ b/src/core/filters/deskew/Params.cpp
@@ -11,27 +11,27 @@ using namespace foundation;
 
 namespace deskew {
 Params::Params(const double deskewAngleDeg, const Dependencies& deps, const AutoManualMode mode)
-    : m_deskewAngleDeg(deskewAngleDeg), m_obliqueDeg(0.0), m_deps(deps), m_mode(mode) {}
+    : m_rotation{deskewAngleDeg, mode}, m_oblique{0.0}, m_deps(deps) {}
 
 Params::Params(const double deskewAngleDeg,
                const double obliqueDeg,
                const Dependencies& deps,
                const AutoManualMode mode)
-    : m_deskewAngleDeg(deskewAngleDeg), m_obliqueDeg(obliqueDeg), m_deps(deps), m_mode(mode) {}
+    : m_rotation{deskewAngleDeg, mode}, m_oblique{obliqueDeg}, m_deps(deps) {}
 
 Params::Params(const QDomElement& deskewEl)
-    : m_deskewAngleDeg(deskewEl.attribute("angle").toDouble()),
-      m_obliqueDeg(deskewEl.attribute("oblique").toDouble()),
-      m_deps(deskewEl.namedItem("dependencies").toElement()),
-      m_mode(deskewEl.attribute("mode") == "manual" ? MODE_MANUAL : MODE_AUTO) {}
+    : m_rotation{deskewEl.attribute("angle").toDouble(),
+                 deskewEl.attribute("mode") == "manual" ? MODE_MANUAL : MODE_AUTO},
+      m_oblique{deskewEl.attribute("oblique").toDouble()},
+      m_deps(deskewEl.namedItem("dependencies").toElement()) {}
 
 Params::~Params() = default;
 
 QDomElement Params::toXml(QDomDocument& doc, const QString& name) const {
   QDomElement el(doc.createElement(name));
-  el.setAttribute("mode", m_mode == MODE_AUTO ? "auto" : "manual");
-  el.setAttribute("angle", Utils::doubleToString(m_deskewAngleDeg));
-  el.setAttribute("oblique", Utils::doubleToString(m_obliqueDeg));
+  el.setAttribute("mode", m_rotation.mode == MODE_AUTO ? "auto" : "manual");
+  el.setAttribute("angle", Utils::doubleToString(m_rotation.angle));
+  el.setAttribute("oblique", Utils::doubleToString(m_oblique.obliqueAngle));
   el.appendChild(m_deps.toXml(doc, "dependencies"));
   return el;
 }

--- a/src/core/filters/deskew/Params.h
+++ b/src/core/filters/deskew/Params.h
@@ -15,6 +15,18 @@ class QDomDocument;
 class QDomElement;
 
 namespace deskew {
+
+/** Rotation (deskew) angle and auto/manual mode. */
+struct RotationParams {
+  double angle = 0.0;
+  AutoManualMode mode = MODE_AUTO;
+};
+
+/** Oblique (shear) angle in degrees. */
+struct ObliqueParams {
+  double obliqueAngle = 0.0;
+};
+
 class Params {
  public:
   // Member-wise copying is OK.
@@ -38,19 +50,18 @@ class Params {
   QDomElement toXml(QDomDocument& doc, const QString& name) const;
 
  private:
-  double m_deskewAngleDeg;
-  double m_obliqueDeg;
+  RotationParams m_rotation;
+  ObliqueParams m_oblique;
   Dependencies m_deps;
-  AutoManualMode m_mode;
 };
 
 
 inline double Params::deskewAngle() const {
-  return m_deskewAngleDeg;
+  return m_rotation.angle;
 }
 
 inline double Params::obliqueAngle() const {
-  return m_obliqueDeg;
+  return m_oblique.obliqueAngle;
 }
 
 inline const Dependencies& Params::dependencies() const {
@@ -58,7 +69,7 @@ inline const Dependencies& Params::dependencies() const {
 }
 
 inline AutoManualMode Params::mode() const {
-  return m_mode;
+  return m_rotation.mode;
 }
 }  // namespace deskew
 

--- a/src/core/filters/deskew/Params.h
+++ b/src/core/filters/deskew/Params.h
@@ -1,5 +1,8 @@
 // Copyright (C) 2019  Joseph Artsimovich <joseph.artsimovich@gmail.com>, 4lex4 <4lex49@zoho.com>
 // Use of this source code is governed by the GNU GPLv3 license that can be found in the LICENSE file.
+//
+// Split Params (Issue #1): refactor into RotationParams and ObliqueParams as requested by Zvezdochiot;
+// in the dev branch this is implemented (single <params> XML preserved for compatibility).
 
 #ifndef SCANTAILOR_DESKEW_PARAMS_H_
 #define SCANTAILOR_DESKEW_PARAMS_H_

--- a/src/core/filters/deskew/Task.cpp
+++ b/src/core/filters/deskew/Task.cpp
@@ -17,7 +17,10 @@
 #include <imageproc/Grayscale.h>
 #include <imageproc/OrthogonalRotation.h>
 #include <imageproc/PolygonRasterizer.h>
+#include <imageproc/Transform.h>
 
+#include <QPolygonF>
+#include <QTransform>
 #include <utility>
 
 #include "DebugImagesImpl.h"
@@ -140,7 +143,34 @@ FilterResultPtr Task::process(const TaskStatus& status, FilterData data) {
       }
       uiData.setMode(MODE_AUTO);
 
-      const std::optional<double> obliqueDeg = findObliqueDegrees(rotatedImage, skewFinder, 5.0);
+      // Find oblique on the deskewed (horizontal) mask for better accuracy (PR #110 feedback).
+      BinaryImage horizontalMask;
+      const double deskewAngleDeg = uiData.effectiveDeskewAngle();
+      if (std::abs(deskewAngleDeg) < 1e-6) {
+        horizontalMask = rotatedImage;
+      } else {
+        const int w = rotatedImage.width();
+        const int h = rotatedImage.height();
+        QTransform rotXform;
+        const QPointF center(0.5 * w, 0.5 * h);
+        rotXform.translate(-center.x(), -center.y());
+        rotXform.rotate(deskewAngleDeg);
+        rotXform.translate(center.x(), center.y());
+        const QRectF srcRectF(0, 0, w, h);
+        QPolygonF dstCorners;
+        dstCorners << rotXform.map(srcRectF.topLeft()) << rotXform.map(srcRectF.topRight())
+                   << rotXform.map(srcRectF.bottomRight()) << rotXform.map(srcRectF.bottomLeft());
+        const QRect dstRect = dstCorners.boundingRect().toAlignedRect();
+        if (dstRect.isValid()) {
+          const QImage srcQ = rotatedImage.toQImage();
+          const QImage dstQ = transform(srcQ, rotXform, dstRect,
+                                        OutsidePixels::assumeWeakColor(Qt::white));
+          horizontalMask = BinaryImage(dstQ);
+        } else {
+          horizontalMask = rotatedImage;
+        }
+      }
+      const std::optional<double> obliqueDeg = findObliqueDegrees(horizontalMask, skewFinder, 5.0);
       if (obliqueDeg) {
         uiData.setEffectiveObliqueAngle(-*obliqueDeg);
       }

--- a/src/core/filters/deskew/Task.cpp
+++ b/src/core/filters/deskew/Task.cpp
@@ -298,5 +298,9 @@ void Task::UiUpdater::updateUI(FilterUiInterface* ui) {
 
   QObject::connect(view, SIGNAL(manualDeskewAngleSet(double)), optWidget, SLOT(manualDeskewAngleSetExternally(double)));
   QObject::connect(optWidget, SIGNAL(manualDeskewAngleSet(double)), view, SLOT(manualDeskewAngleSetExternally(double)));
+  QObject::connect(view, SIGNAL(manualObliqueAngleSet(double)), optWidget,
+                   SLOT(manualObliqueAngleSetExternally(double)));
+  QObject::connect(optWidget, SIGNAL(manualObliqueAngleSet(double)), view,
+                   SLOT(manualObliqueAngleSetExternally(double)));
 }
 }  // namespace deskew

--- a/src/core/filters/deskew/Task.cpp
+++ b/src/core/filters/deskew/Task.cpp
@@ -26,6 +26,7 @@
 #include "FilterData.h"
 #include "FilterUiInterface.h"
 #include "ImageView.h"
+#include "ObliqueFinder.h"
 #include "OptionsWidget.h"
 #include "TaskStatus.h"
 #include "filters/select_content/Task.h"
@@ -138,6 +139,11 @@ FilterResultPtr Task::process(const TaskStatus& status, FilterData data) {
         uiData.setEffectiveDeskewAngle(0);
       }
       uiData.setMode(MODE_AUTO);
+
+      const std::optional<double> obliqueDeg = findObliqueDegrees(rotatedImage, skewFinder, 5.0);
+      if (obliqueDeg) {
+        uiData.setEffectiveObliqueAngle(-*obliqueDeg);
+      }
 
       Params newParams(uiData.effectiveDeskewAngle(), uiData.effectiveObliqueAngle(), deps, uiData.mode());
       m_settings->setPageParams(m_pageId, newParams);

--- a/src/core/filters/deskew/Task.cpp
+++ b/src/core/filters/deskew/Task.cpp
@@ -163,8 +163,7 @@ FilterResultPtr Task::process(const TaskStatus& status, FilterData data) {
         const QRect dstRect = dstCorners.boundingRect().toAlignedRect();
         if (dstRect.isValid()) {
           const QImage srcQ = rotatedImage.toQImage();
-          const QImage dstQ = transform(srcQ, rotXform, dstRect,
-                                        OutsidePixels::assumeWeakColor(Qt::white));
+          const QImage dstQ = transform(srcQ, rotXform, dstRect, OutsidePixels::assumeWeakColor(Qt::white));
           horizontalMask = BinaryImage(dstQ);
         } else {
           horizontalMask = rotatedImage;

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ set(sources
     main.cpp
     TestContentSpanFinder.cpp
     TestDeskewParams.cpp
+    TestObliqueFinder.cpp
     TestImageId.cpp
     TestMargins.cpp
     TestPageId.cpp

--- a/src/core/tests/TestObliqueFinder.cpp
+++ b/src/core/tests/TestObliqueFinder.cpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2019  Joseph Artsimovich <joseph.artsimovich@gmail.com>, 4lex4 <4lex49@zoho.com>
+// Use of this source code is governed by the GNU GPL v3 license that can be found in the LICENSE file.
+
+#include <BinaryImage.h>
+#include <SkewFinder.h>
+#include <filters/deskew/ObliqueFinder.h>
+
+#include <boost/test/unit_test.hpp>
+
+namespace Tests {
+using namespace deskew;
+using namespace imageproc;
+
+BOOST_AUTO_TEST_SUITE(ObliqueFinderTestSuite)
+
+BOOST_AUTO_TEST_CASE(build_sausage_mask_null_returns_null) {
+  const BinaryImage empty;
+  const BinaryImage result = buildSausageMask(empty);
+  BOOST_CHECK(result.isNull());
+}
+
+BOOST_AUTO_TEST_CASE(build_sausage_mask_preserves_size) {
+  BinaryImage img(50, 30, WHITE);
+  img.fill(QRect(10, 5, 20, 10), BLACK);
+  const BinaryImage result = buildSausageMask(img);
+  BOOST_REQUIRE(!result.isNull());
+  BOOST_CHECK_EQUAL(result.width(), 50);
+  BOOST_CHECK_EQUAL(result.height(), 30);
+}
+
+BOOST_AUTO_TEST_CASE(find_oblique_null_mask_returns_nullopt) {
+  const BinaryImage empty;
+  SkewFinder finder;
+  const auto result = findObliqueDegrees(empty, finder, 5.0);
+  BOOST_CHECK(!result.has_value());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace Tests

--- a/src/imageproc/Binarize.cpp
+++ b/src/imageproc/Binarize.cpp
@@ -395,9 +395,10 @@ BinaryImage binarizeWindow(const QImage& src,
 
   const int areaFull = w * h;
   assert(areaFull > 0);
-  const double meanFull = (double) integralImage.sum(QRect(0, 0, w, h)) / areaFull;
+  const uint64_t meanFull = integralImage.sum(QRect(0, 0, w, h)) / areaFull;
   double deviationMax = 0.0;
   double deviationMin = 256.0;
+  const double coefw = k * 3.0;  // translate from Wolf to Window coef.
 
   grayLine = gray.bits();
   for (int y = 0; y < h; ++y) {
@@ -416,8 +417,8 @@ BinaryImage binarizeWindow(const QImage& src,
       const double mean = windowSum * rArea;
       const double sqmean = windowSqsum * rArea;
 
-      const double variance = sqmean - mean * mean;
-      const double deviation = std::sqrt(std::fabs(variance));
+      const double variance = std::fabs(sqmean - mean * mean);
+      const double deviation = std::sqrt(variance);
 
       deviationMax = (deviation > deviationMax) ? deviation : deviationMax;
       deviationMin = (deviation < deviationMin) ? deviation : deviationMin;
@@ -425,12 +426,13 @@ BinaryImage binarizeWindow(const QImage& src,
     grayLine += grayBpl;
   }
 
-  const double deviationD = (deviationMax > deviationMin) ? (deviationMax - deviationMin) : 1.0;
+  const double deviationD = deviationMax - deviationMin;
 
   BinaryImage bwImg(w, h);
   uint32_t* bwLine = bwImg.data();
   const int bwWpl = bwImg.wordsPerLine();
 
+  const uint32_t msb = uint32_t(1) << 31;
   grayLine = gray.bits();
   for (int y = 0; y < h; ++y) {
     const int top = (y > windowLowerHalf) ? (y - windowLowerHalf) : 0;
@@ -448,17 +450,16 @@ BinaryImage binarizeWindow(const QImage& src,
       const double mean = windowSum * rArea;
       const double sqmean = windowSqsum * rArea;
 
-      const double variance = sqmean - mean * mean;
-      const double deviation = std::sqrt(std::fabs(variance));
+      const double variance = std::fabs(sqmean - mean * mean);
+      const double deviation = std::sqrt(variance);
 
       const double md = (mean + 1.0 - delta) / (meanFull + deviation + 1.0);
       const double kdm = (meanFull + meanFull + 1.0) / (deviation + 1.0);
-      const double kds = (deviation - deviationMin) / deviationD;
+      const double kds = (deviationD > 0.0) ? ((deviation - deviationMin) / deviationD) : 1.0;
       const double kd = 1.0 + kdm * kds;
 
-      const double threshold = mean * (1.0 - k * 3.0 * md / kd);
+      const double threshold = mean * (1.0 - coefw * md / kd);
 
-      const uint32_t msb = uint32_t(1) << 31;
       const uint32_t mask = msb >> (x & 31);
       if ((grayLine[x] < lowerBound) || ((grayLine[x] <= upperBound) && (int(grayLine[x]) < threshold))) {
         // black


### PR DESCRIPTION
Implements the oblique feature for the deskew step as requested in **Issue #53**.

## Summary
- **Manual oblique:** New spinbox "Oblique (°)" in the deskew options (default 0 = perpendicular; negative = left, positive = right) to shear between horizontal and vertical guides and align vertical text borders, making dewarping easier.
- **Auto oblique:** `ObliqueFinder` estimates oblique angle using a sausage-mask + Radon transform (skew difference between original and 90°-rotated mask), clamped to ±5°.
- **Transform:** Oblique is applied as a post-rotation vertical shear via `QTransform` (`setPostOblique` / `calcPostRotateXform`), as discussed in the issue (m21/m23-style shear).
- **Params:** Oblique is stored in project XML and in `Params` (refactored with `ObliqueParams`). Auto mode uses detected oblique; manual mode allows user override.

## References
- Closes #53
- Algorithm and UI behaviour follow the approach described by @zvezdochiot in the issue comments.