### PR TITLE
chore: expand .gitignore for Flatpak, IDEs, and tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,18 +7,20 @@ bin/
 lib/
 *.dir/
 
-# CMake
+# CMake (generated); keep tracked project modules under cmake/
 CMakeCache.txt
 CMakeFiles/
 cmake_install.cmake
 Makefile
 *.cmake
 !CMakeLists.txt
+!cmake/**/*.cmake
 *.cbp
 CTestTestfile.cmake
 _deps/
 install_manifest.txt
 compile_commands.json
+CMakeUserPresets.json
 
 # C/C++ compilado
 *.o
@@ -61,6 +63,7 @@ ui_*.h
 *.config
 
 # IDEs y editores
+.cursor/
 .vscode/
 .idea/
 *.sublime-project
@@ -69,6 +72,14 @@ ui_*.h
 *.swp
 *.swo
 .*.sw?
+.clangd
+.cache/clangd/
+*.code-workspace
+
+# Visual Studio (CMake “Open folder”)
+.vs/
+CMakeSettings.json
+CppProperties.json
 
 # Sistema operativo
 .DS_Store
@@ -77,6 +88,7 @@ ui_*.h
 Thumbs.db
 ehthumbs.db
 Desktop.ini
+.directory
 
 # Depuradores y profiling
 *.core
@@ -91,6 +103,14 @@ Desktop.ini
 perf.data
 perf.data.old
 
+# Tags / navegación C
+tags
+TAGS
+GTAGS
+GRTAGS
+GPATH
+cscope.out
+
 # Documentación generada
 doc/html/
 doc/latex/
@@ -101,8 +121,17 @@ docs/_build/
 Testing/
 test_results/
 coverage/
-*.gcov
 lcov.info
+
+# Python (scripts/, herramientas locales)
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+venv/
+.venv/
 
 # Empaquetado y distribución
 *.tar
@@ -112,7 +141,19 @@ lcov.info
 *.deb
 *.rpm
 *.msi
+*.AppImage
+*.flatpak
 packaging/build/
+
+# Flatpak / flatpak-builder (builds locales y CI)
+.flatpak-builder/
+flatpak/.flatpak-builder/
+repo/
+build-dir/
+
+# Parches y merge
+*.orig
+*.rej
 
 # Variables de entorno / local
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ bin/
 lib/
 *.dir/
 
-# CMake (generated); keep tracked project modules under cmake/
+# CMake (generated). Tracked helper modules live under cmake/.
 CMakeCache.txt
 CMakeFiles/
 cmake_install.cmake
@@ -22,7 +22,7 @@ install_manifest.txt
 compile_commands.json
 CMakeUserPresets.json
 
-# C/C++ compilado
+# C/C++ build artifacts
 *.o
 *.obj
 *.a
@@ -62,7 +62,7 @@ ui_*.h
 *.includes
 *.config
 
-# IDEs y editores
+# Editors / IDEs
 .cursor/
 .vscode/
 .idea/
@@ -76,12 +76,12 @@ ui_*.h
 .cache/clangd/
 *.code-workspace
 
-# Visual Studio (CMake “Open folder”)
+# Visual Studio (CMake "Open Folder")
 .vs/
 CMakeSettings.json
 CppProperties.json
 
-# Sistema operativo
+# Operating system junk
 .DS_Store
 .DS_Store?
 ._*
@@ -90,7 +90,7 @@ ehthumbs.db
 Desktop.ini
 .directory
 
-# Depuradores y profiling
+# Debuggers / profiling
 *.core
 /core
 *.stackdump
@@ -103,7 +103,7 @@ Desktop.ini
 perf.data
 perf.data.old
 
-# Tags / navegación C
+# Ctags / cscope
 tags
 TAGS
 GTAGS
@@ -111,29 +111,19 @@ GRTAGS
 GPATH
 cscope.out
 
-# Documentación generada
+# Generated docs
 doc/html/
 doc/latex/
 docs/_build/
 *.dox
 
-# Tests y cobertura
+# Tests / coverage output
 Testing/
 test_results/
 coverage/
 lcov.info
 
-# Python (scripts/, herramientas locales)
-__pycache__/
-*.py[cod]
-*$py.class
-.pytest_cache/
-.mypy_cache/
-.ruff_cache/
-venv/
-.venv/
-
-# Empaquetado y distribución
+# Packaging / distribution artifacts
 *.tar
 *.tar.gz
 *.zip
@@ -145,23 +135,23 @@ venv/
 *.flatpak
 packaging/build/
 
-# Flatpak / flatpak-builder (builds locales y CI)
+# flatpak-builder output (local smoke builds / CI)
 .flatpak-builder/
 flatpak/.flatpak-builder/
 repo/
 build-dir/
 
-# Parches y merge
+# Patch / merge leftovers
 *.orig
 *.rej
 
-# Variables de entorno / local
+# Local env / CMake overrides
 .env
 .env.local
 *.local
 local.cmake
 
-# Otros
+# Misc
 *.log
 *.tmp
 *.temp


### PR DESCRIPTION
## Changes
- **CMake**: ignore generated `*.cmake` but keep versioned modules with `!cmake/**/*.cmake`; add `CMakeUserPresets.json`.
- **Flatpak / packaging**: `.flatpak-builder/`, `repo/`, `build-dir/`, `*.flatpak`, `*.AppImage`.
- **IDEs**: `.clangd`, `.cache/clangd/`, VS CMake Open Folder (`.vs/`, `CMakeSettings.json`, `CppProperties.json`), `*.code-workspace`.
- **Misc**: C tag/cscope index files, `*.orig`/`*.rej`, KDE `.directory`, section comments in English only.

Follow-up: dropped Python/venv patterns — there are no tracked `.py` files in this repository (see review discussion).