### PR TITLE
docs(README): Windows VC++ Redistributable and supported OS (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Go to [this repository](https://github.com/ScanTailor-Advanced/scantailor-libs-b
 
 **Windows – large JPEG/PNG (issue #20):** If large-format JPEG or PNG files fail to load on Windows, ensure the build uses **libjpeg-turbo** (or libjpeg 9+) and a recent libpng. The [scantailor-libs-build](https://github.com/ScanTailor-Advanced/scantailor-libs-build) repository provides compatible libraries.
 
+**Windows – Visual C++ runtime (issue #101):** Pre-built binaries are linked with **Microsoft Visual C++** (MSVC) runtimes. If the application does not start and Windows reports missing **`VCRUNTIME*.dll`**, **`MSVCP*.dll`**, or similar, install the **latest supported x64 “Visual C++ Redistributable”** from Microsoft’s page: [Latest supported VC++ Redistributable downloads](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170). Match **x64** vs **x86** to the build you run.
+
+**Windows – supported OS versions (issue #101):** Release builds follow upstream **Qt** and **toolchain** support policies; **legacy Windows** (for example Windows 7) is **not** exercised in this project’s CI and is **best-effort only**. You may need an **older tagged release** or a **self-built** binary against an older Qt/MSVC stack. Community reports (including compatibility tips) are welcome in the issue tracker.
+
 **Linux – Wayland (issue #97):** If you see rendering issues (blank or corrupted windows) when running under Wayland, try starting the application with `QT_QPA_PLATFORM=xcb` to use the X11 compatibility layer.
 
 **Linux – Flatpak / Flathub (issue #105):** A Flatpak manifest is provided in `flatpak/org.scantailor.Advanced.json`. To build locally: `flatpak-builder --user --force-clean build flatpak/org.scantailor.Advanced.json` (requires `flatpak` and `flatpak-builder`). To publish on Flathub, use a distinct application ID (e.g. `org.scantailor.Advanced`) so it does not conflict with the original ScanTailor package.


### PR DESCRIPTION
## Context

Following the discussion in **#101** (missing MSVC runtime DLLs on Windows, and questions around **legacy Windows** / Qt versions), **@vigri** suggested adding a short **README** note.

As **maintainer**, I am opening this PR myself (branch `docs/readme-windows-vcredist-101`) instead of waiting for a separate contributor PR, so the documentation matches what we already recommended in the issue thread.

## What this PR adds

- **Visual C++ Redistributable**: when pre-built binaries fail to start with missing `VCRUNTIME*.dll` / `MSVCP*.dll`, install the latest supported **x64** (or matching architecture) VC++ runtime from Microsoft’s official page (linked in README).
- **Supported OS scope**: clarify that **legacy Windows** (e.g. Windows 7) is **not covered by project CI** and is **best-effort**, with pointers to older tags or self-built stacks.

Refs: #101