### PR TITLE
fix(ui): preserve Output preview zoom on parameter reload (#21)

### DIFF
--- a/src/app/MainWindow.cpp
+++ b/src/app/MainWindow.cpp
@@ -106,7 +106,7 @@ MainWindow::MainWindow()
       m_interactiveQueue(std::make_unique<ProcessingTaskQueue>()),
       m_outOfMemoryDialog(std::make_unique<OutOfMemoryDialog>()),
       m_curFilter(0),
-      m_savedZoomLevel(1.0),
+      m_savedMainAreaViewState(),
       m_ignoreSelectionChanges(0),
       m_ignorePageOrderingChanges(0),
       m_debug(false),
@@ -710,6 +710,54 @@ void MainWindow::setOptionsWidget(FilterOptionsWidget* widget, const Ownership o
   connect(widget, SIGNAL(fixDpiRequested()), this, SLOT(fixDpiDialogRequested()));
 }  // MainWindow::setOptionsWidget
 
+ImageViewBase* MainWindow::findPrimaryImageView(QWidget* root) {
+  if (!root) {
+    return nullptr;
+  }
+  if (auto* tabs = qobject_cast<output::TabbedImageView*>(root)) {
+    QWidget* const page = tabs->currentWidget();
+    if (page) {
+      return Utils::castOrFindChild<ImageViewBase*>(page);
+    }
+    return nullptr;
+  }
+  return Utils::castOrFindChild<ImageViewBase*>(root);
+}
+
+void MainWindow::applySavedMainAreaViewState(ImageViewBase* view, const SavedMainAreaViewState& state) {
+  if (!view) {
+    return;
+  }
+  view->setZoomLevel(state.zoom);
+  if (!state.hasScrollNorm) {
+    return;
+  }
+  QScrollBar* const h = view->horizontalScrollBar();
+  QScrollBar* const v = view->verticalScrollBar();
+  const int hr = h->maximum() - h->minimum();
+  const int vr = v->maximum() - v->minimum();
+  if (hr <= 0 || vr <= 0) {
+    return;
+  }
+  const double nx = qBound(0.0, state.scrollNormX, 1.0);
+  const double ny = qBound(0.0, state.scrollNormY, 1.0);
+  h->setValue(h->minimum() + qRound(nx * hr));
+  v->setValue(v->minimum() + qRound(ny * vr));
+}
+
+void MainWindow::scheduleSavedMainAreaViewStateRestore(const QPointer<ImageViewBase>& view) {
+  if (view.isNull()) {
+    return;
+  }
+  const SavedMainAreaViewState state = m_savedMainAreaViewState;
+  QTimer::singleShot(0, this, [view, state]() {
+    if (view.isNull()) {
+      return;
+    }
+    MainWindow::applySavedMainAreaViewState(view.data(), state);
+  });
+}
+
 void MainWindow::setImageWidget(QWidget* widget, const Ownership ownership, DebugImages* debugImages, bool overlay) {
   if (isBatchProcessingInProgress() && (widget != m_batchProcessingWidget.get())) {
     if (ownership == TRANSFER_OWNERSHIP) {
@@ -720,8 +768,19 @@ void MainWindow::setImageWidget(QWidget* widget, const Ownership ownership, Debu
 
   if (!overlay && m_imageFrameLayout->count() > 0) {
     QWidget* oldW = m_imageFrameLayout->widget(0);
-    if (ImageViewBase* oldView = Utils::castOrFindChild<ImageViewBase*>(oldW)) {
-      m_savedZoomLevel = oldView->zoomLevel();
+    if (ImageViewBase* oldView = findPrimaryImageView(oldW)) {
+      m_savedMainAreaViewState.zoom = oldView->zoomLevel();
+      QScrollBar* const h = oldView->horizontalScrollBar();
+      QScrollBar* const v = oldView->verticalScrollBar();
+      const int hr = h->maximum() - h->minimum();
+      const int vr = v->maximum() - v->minimum();
+      if (hr > 0 && vr > 0) {
+        m_savedMainAreaViewState.hasScrollNorm = true;
+        m_savedMainAreaViewState.scrollNormX = double(h->value() - h->minimum()) / hr;
+        m_savedMainAreaViewState.scrollNormY = double(v->value() - v->minimum()) / vr;
+      } else {
+        m_savedMainAreaViewState.hasScrollNorm = false;
+      }
     }
   }
 
@@ -739,8 +798,8 @@ void MainWindow::setImageWidget(QWidget* widget, const Ownership ownership, Debu
       if (overlay) {
         m_imageFrameLayout->setCurrentWidget(widget);
       }
-      if (ImageViewBase* newView = Utils::castOrFindChild<ImageViewBase*>(widget)) {
-        newView->setZoomLevel(m_savedZoomLevel);
+      if (ImageViewBase* newView = findPrimaryImageView(widget)) {
+        scheduleSavedMainAreaViewStateRestore(QPointer<ImageViewBase>(newView));
       }
     }
   } else {

--- a/src/app/MainWindow.h
+++ b/src/app/MainWindow.h
@@ -195,6 +195,19 @@ class MainWindow : public QMainWindow, private FilterUiInterface, private Ui::Ma
 
   static void removeWidgetsFromLayout(QLayout* layout);
 
+  struct SavedMainAreaViewState {
+    double zoom = 1.0;
+    bool hasScrollNorm = false;
+    double scrollNormX = 0.5;
+    double scrollNormY = 0.5;
+  };
+
+  static ImageViewBase* findPrimaryImageView(QWidget* root);
+
+  static void applySavedMainAreaViewState(ImageViewBase* view, const SavedMainAreaViewState& state);
+
+  void scheduleSavedMainAreaViewStateRestore(const QPointer<ImageViewBase>& view);
+
   void setOptionsWidget(FilterOptionsWidget* widget, Ownership ownership) override;
 
   void setImageWidget(QWidget* widget,
@@ -323,7 +336,7 @@ class MainWindow : public QMainWindow, private FilterUiInterface, private Ui::Ma
   QObjectCleanupHandler m_imageWidgetCleanup;
   std::unique_ptr<OutOfMemoryDialog> m_outOfMemoryDialog;
   int m_curFilter;
-  double m_savedZoomLevel;
+  SavedMainAreaViewState m_savedMainAreaViewState;
   int m_ignoreSelectionChanges;
   int m_ignorePageOrderingChanges;
   bool m_debug;


### PR DESCRIPTION
## Summary

Fixes the Output-stage behaviour described in #21: changing processing options triggered a full main-area rebuild, and the preview often jumped back to a whole-page view because zoom/scroll state was taken from the wrong `ImageViewBase` (depth-first search) and the first `resizeEvent` recentered the focal point.

## What changed

- When the root image widget is `output::TabbedImageView`, capture and restore zoom/scroll from the **active tab** (`currentWidget()`) instead of the first `ImageViewBase` in the object tree.
- Persist normalized horizontal/vertical scrollbar positions together with zoom.
- Reapply saved zoom and scroll on a **queued single-shot** timer so it runs after the initial layout/`resizeEvent`, avoiding an immediate wipe of the focal point.

## How to test

1. Open a project, go to **Output**, stay on the **Output** tab.
2. Zoom in (mouse wheel) so only part of the page is visible.
3. Change a setting that forces a reload (e.g. binarization / mode), as in #21.
4. Confirm zoom and approximate framing stay comparable without having to zoom in again each time.

Optional: repeat with another tab selected (e.g. Dewarping) to confirm the active tab’s view is what gets preserved.

Closes #21 if maintainers agree this fully matches the requested behaviour.