### PR TITLE
fix(ci): replace libtiff5 with libtiff6 and add -y flag to apt-get install

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v5
     
     - name: Install dependencies
-      run: sudo apt install gcc g++ cmake libjpeg-dev libpng-dev libtiff5 libtiff5-dev libboost-test-dev qtbase5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libpthread-stubs0-dev rpm libfuse2
+      run: sudo apt install -y gcc g++ cmake libjpeg-dev libpng-dev libtiff6 libtiff5-dev libboost-test-dev qtbase5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libpthread-stubs0-dev rpm libfuse2
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.


### PR DESCRIPTION
**Problem**
The dependency installation step fails on Ubuntu 24.04 since libtiff5 was removed in newer versions.:

**Fix**
Replaced libtiff5 with libtiff6

Added `-y` flag to `apt-get install` for non-interactive execution