### PR TITLE
fix(ci): update apt dependencies for Ubuntu 24.04 (Noble) & AppImage

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,33 +37,33 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B "${{ github.workspace }}/build" -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build "${{ github.workspace }}/build" --config ${{env.BUILD_TYPE}}
       
     - name: Create DEB package
-      working-directory: ${{github.workspace}}/build
+      working-directory: "${{ github.workspace }}/build"
       run: |
         cpack -G "DEB"
         mv scantailor*.deb scantailor.deb
       
     - name: Create RPM package
-      working-directory: ${{github.workspace}}/build
+      working-directory: "${{ github.workspace }}/build"
       run: |
         cpack -G "RPM"
         mv scantailor*.rpm scantailor.rpm
         
     - name: Create AppImage package
-      working-directory: ${{github.workspace}}/build
+      working-directory: "${{ github.workspace }}/build"
       run: |
         wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
         chmod +x linuxdeploy-x86_64.AppImage
         ./linuxdeploy-x86_64.AppImage \
           --appdir AppDir \
-          --desktop-file ${{github.workspace}}/src/resources/unix/scantailor.desktop \
-          --icon-file ${{github.workspace}}/src/resources/ScanTailor.png \
+          --desktop-file "${{ github.workspace }}/build/scantailor.desktop" \
+          --icon-file "${{ github.workspace }}/src/resources/ScanTailor.png" \
           --executable scantailor \
           --output appimage
         mv ScanTailor*.AppImage scantailor.AppImage

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -60,7 +60,12 @@ jobs:
       run: |
         wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
         chmod +x linuxdeploy-x86_64.AppImage
-        ./linuxdeploy-x86_64.AppImage --appdir AppDir --desktop-file ../src/resources/unix/scantailor.desktop --icon-file ../src/resources/ScanTailor.png --executable scantailor --output appimage
+        ./linuxdeploy-x86_64.AppImage \
+          --appdir AppDir \
+          --desktop-file ${{github.workspace}}/src/resources/unix/scantailor.desktop \
+          --icon-file ${{github.workspace}}/src/resources/ScanTailor.png \
+          --executable scantailor \
+          --output appimage
         mv ScanTailor*.AppImage scantailor.AppImage
       
     - name: Upload Linux bin

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,9 +19,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    
+
     - name: Install dependencies
-      run: sudo apt install -y gcc g++ cmake libjpeg-dev libpng-dev libtiff6 libtiff5-dev libboost-test-dev qtbase5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libpthread-stubs0-dev rpm libfuse2
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --fix-missing \
+          gcc g++ cmake \
+          libjpeg-dev libpng-dev \
+          libtiff6 libtiff5-dev \
+          libboost-test-dev \
+          qtbase5-dev libqt5svg5-dev \
+          qttools5-dev qttools5-dev-tools \
+          libqt5opengl5-dev \
+          libpthread-stubs0-dev \
+          rpm libfuse2t64
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v5
     
     - name: Install dependencies
-      run: sudo apt install gcc g++ cmake libjpeg-dev libpng-dev libtiff5 libtiff5-dev libboost-test-dev qtbase5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libpthread-stubs0-dev rpm libfuse2
+      run: sudo apt install -y gcc g++ cmake libjpeg-dev libpng-dev libtiff6 libtiff5-dev libboost-test-dev qtbase5-dev libqt5svg5-dev qttools5-dev qttools5-dev-tools libqt5opengl5-dev libpthread-stubs0-dev rpm libfuse2
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/src/resources/unix/scantailor.desktop.in
+++ b/src/resources/unix/scantailor.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=@VERSION@
+Version=1.0
 Name=ScanTailor Advanced
 Comment=Interactive post-processing tool for scanned pages
 Exec=scantailor %f


### PR DESCRIPTION
The dependency installation step fails on Ubuntu 24.04 (Noble) due to several package changes introduced in this release:

- `libtiff5` was removed — replaced by `libtiff6`
- `libfuse2` was renamed to `libfuse2t64`

Moreover:
- missing `apt-get update` causes 404 errors due to stale package index on GitHub-hosted runners
- missing `-y` flag causes non-interactive execution to hang