### PR TITLE
build(release): deb Depends and artifact actions (#64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           mv "$OUT" "../scantailor-advanced-${{ github.ref_name }}-x86_64.AppImage"
 
       - name: Upload AppImage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: appimage
           path: scantailor-advanced-*-x86_64.AppImage
@@ -96,10 +96,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-deb, build-appimage]
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: deb-package
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: appimage
 

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -46,7 +46,9 @@ if command -v dpkg-shlibdeps >/dev/null 2>&1; then
   fi
 fi
 if [[ -z "$DEPS" ]]; then
-  DEPS="libc6, libstdc++6, libgcc-s1, libqt5core5t64 | libqt5core5a, libqt5gui5t64 | libqt5gui5, libqt5widgets5t64 | libqt5widgets5, libqt5svg5t64 | libqt5svg5, libqt5xml5t64 | libqt5xml5, libqt5network5t64 | libqt5network5, libboost-filesystem1.83.0 | libboost-filesystem1.74.0, libjpeg62-turbo | libjpeg8, libpng16-16, libtiff6, zlib1g"
+  # Fallback when dpkg-shlibdeps is unavailable (e.g. cross-build). Include common
+  # libjpeg variants across Debian/Ubuntu (see issue #64 / Ubuntu 22.04 vs bookworm).
+  DEPS="libc6, libstdc++6, libgcc-s1, libqt5core5t64 | libqt5core5a, libqt5gui5t64 | libqt5gui5, libqt5widgets5t64 | libqt5widgets5, libqt5svg5t64 | libqt5svg5, libqt5xml5t64 | libqt5xml5, libqt5network5t64 | libqt5network5, libboost-filesystem1.83.0 | libboost-filesystem1.74.0, libjpeg62-turbo | libjpeg-turbo8 | libjpeg8, libpng16-16, libtiff6, zlib1g"
 fi
 
 cat > "${DEBIAN_DIR}/control" << EOF
@@ -62,7 +64,7 @@ Description: Interactive post-processing tool for scanned pages
  with improvements for page splitting, deskewing, content selection,
  margins, dewarping and output. Supports batch processing and multiple
  output formats.
-Homepage: https://github.com/4lex4/scantailor-advanced
+Homepage: https://github.com/ScanTailor-Advanced/scantailor-advanced
 EOF
 
 # Optional: refresh icon and desktop caches after install


### PR DESCRIPTION
Small packaging/release hardening for Linux installers discussed in [#64](https://github.com/ScanTailor-Advanced/scantailor-advanced/issues/64):

- **`.deb` fallback `Depends:`** (when `dpkg-shlibdeps` is not used): add `libjpeg-turbo8` as an alternative alongside `libjpeg62-turbo` / `libjpeg8` for Ubuntu 22.04-style stacks.
- **`control` Homepage:** point to the current **ScanTailor-Advanced** repository URL.
- **`release.yml`:** bump `actions/upload-artifact` / `actions/download-artifact` for the AppImage job and the release aggregation job to **v5** (matches the deb job; avoids mixed major versions).

Full end-to-end validation still depends on tagging a release; this only tightens metadata and CI glue.

Refs #64