### PR TITLE
fix: P0 issues — Wayland, menus, content box, spread order, deskew/oblique

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Go to [this repository](https://github.com/ScanTailor-Advanced/scantailor-libs-b
 
 **Windows – supported OS versions (issue #101):** Release builds follow upstream **Qt** and **toolchain** support policies; **legacy Windows** (for example Windows 7) is **not** exercised in this project’s CI and is **best-effort only**. You may need an **older tagged release** or a **self-built** binary against an older Qt/MSVC stack. Community reports (including compatibility tips) are welcome in the issue tracker.
 
-**Linux – Wayland (issue #97):** If you see rendering issues (blank or corrupted windows) when running under Wayland, try starting the application with `QT_QPA_PLATFORM=xcb` to use the X11 compatibility layer.
+**Linux – Wayland (issue #97):** On Qt5 builds, if `XDG_SESSION_TYPE` is `wayland` and `QT_QPA_PLATFORM` is not set, the application defaults to the X11 (`xcb`) platform plugin to avoid broken dialogs and painting. Set **`SCANTAILOR_NO_XCB_FALLBACK=1`** in the environment to keep native Wayland and, if needed, set `QT_QPA_PLATFORM=wayland` or `QT_QPA_PLATFORM=xcb` yourself.
 
 **Linux – Flatpak / Flathub (issue #105):** End users should prefer **pre-built** binaries from [GitHub Releases](https://github.com/ScanTailor-Advanced/scantailor-advanced/releases) when available (`.deb` / AppImage on tagged releases). A Flatpak manifest for **maintainers** is in `flatpak/org.scantailor.Advanced.json` (`flatpak-builder --user --force-clean build flatpak/org.scantailor.Advanced.json`). Publishing on Flathub needs a **new** application ID (e.g. `org.scantailor.Advanced`) so it does not replace the legacy `com.github._4lex4.*` app.
 

--- a/src/app/MainWindow.cpp
+++ b/src/app/MainWindow.cpp
@@ -10,6 +10,7 @@
 #include <QDir>
 #include <QFileDialog>
 #include <QFileSystemModel>
+#include <QMenu>
 #include <QMessageBox>
 #include <QResource>
 #include <QScrollBar>
@@ -301,6 +302,7 @@ MainWindow::MainWindow()
   });
 
   connect(actionFixDpi, SIGNAL(triggered(bool)), SLOT(fixDpiDialogRequested()));
+  connect(actionReverseTwoPageOrder, SIGNAL(triggered(bool)), SLOT(toggleTwoPageSpreadReadingOrder()));
   connect(actionRelinking, SIGNAL(triggered(bool)), SLOT(showRelinkingDialog()));
 #ifdef ENABLE_DEBUG_FEATURES
   connect(actionDebug, SIGNAL(toggled(bool)), SLOT(debugToggled(bool)));
@@ -1016,7 +1018,8 @@ void MainWindow::pageContextMenuRequested(const PageInfo& pageInfo_, const QPoin
     goToPage(pageInfo.id());
   }
 
-  QMenu menu;
+  // Parent widget helps correct multi-monitor placement (issue #75).
+  QMenu menu(thumbView);
 
   auto& iconProvider = IconProvider::getInstance();
   QAction* insBefore = menu.addAction(iconProvider.getIcon("insert-before"), tr("Insert before ..."));
@@ -1036,12 +1039,24 @@ void MainWindow::pageContextMenuRequested(const PageInfo& pageInfo_, const QPoin
   }
 }  // MainWindow::pageContextMenuRequested
 
+void MainWindow::toggleTwoPageSpreadReadingOrder() {
+  if (!isProjectLoaded() || !m_pages) {
+    return;
+  }
+  const Qt::LayoutDirection nextDir
+      = (m_pages->layoutDirection() == Qt::LeftToRight) ? Qt::RightToLeft : Qt::LeftToRight;
+  m_pages->setLayoutDirection(nextDir);
+  m_outFileNameGen.setLayoutDirection(nextDir);
+  resetThumbSequence(currentPageOrderProvider(), ThumbnailSequence::KEEP_SELECTION);
+  invalidateAllThumbnails();
+}
+
 void MainWindow::pastLastPageContextMenuRequested(const QPoint& screenPos) {
   if (!isProjectLoaded()) {
     return;
   }
 
-  QMenu menu;
+  QMenu menu(thumbView);
   menu.addAction(IconProvider::getInstance().getIcon("insert-here"), tr("Insert here ..."));
 
   if (menu.exec(screenPos)) {
@@ -1579,6 +1594,7 @@ void MainWindow::updateProjectActions() {
   actionSaveProjectAs->setEnabled(loaded);
   actionFixDpi->setEnabled(loaded);
   actionRelinking->setEnabled(loaded);
+  actionReverseTwoPageOrder->setEnabled(loaded);
 }
 
 bool MainWindow::isBatchProcessingInProgress() const {

--- a/src/app/MainWindow.h
+++ b/src/app/MainWindow.h
@@ -118,6 +118,8 @@ class MainWindow : public QMainWindow, private FilterUiInterface, private Ui::Ma
 
   void pastLastPageContextMenuRequested(const QPoint& screenPos);
 
+  void toggleTwoPageSpreadReadingOrder();
+
   void thumbViewFocusToggled(bool checked);
 
   void thumbViewScrolled();

--- a/src/app/MainWindow.ui
+++ b/src/app/MainWindow.ui
@@ -75,6 +75,7 @@
     </widget>
     <addaction name="actionFixDpi"/>
     <addaction name="actionRelinking"/>
+    <addaction name="actionReverseTwoPageOrder"/>
     <addaction name="separator"/>
     <addaction name="actionDebug"/>
     <addaction name="separator"/>
@@ -1206,6 +1207,20 @@ QToolButton:pressed {
   <action name="actionRelinking">
    <property name="text">
     <string>Relinking ...</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
+   <property name="autoRepeat">
+    <bool>false</bool>
+   </property>
+  </action>
+  <action name="actionReverseTwoPageOrder">
+   <property name="text">
+    <string>Reverse two-page spread order</string>
+   </property>
+   <property name="toolTip">
+    <string>Swap left/right page order for two-page scans (e.g. Japanese book reading order).</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -18,6 +18,12 @@
 
 int main(int argc, char* argv[]) {
 #if QT_VERSION_MAJOR == 5
+  // Issue #97: Qt5 on Wayland can corrupt dialogs; use X11 unless opted out.
+  if (!qEnvironmentVariableIsSet("SCANTAILOR_NO_XCB_FALLBACK")) {
+    if (qgetenv("XDG_SESSION_TYPE") == "wayland" && qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+      qputenv("QT_QPA_PLATFORM", QByteArrayLiteral("xcb"));
+    }
+  }
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
   QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)

--- a/src/core/OutputFileNameGenerator.h
+++ b/src/core/OutputFileNameGenerator.h
@@ -24,6 +24,8 @@ class OutputFileNameGenerator {
 
   void performRelinking(const AbstractRelinker& relinker);
 
+  void setLayoutDirection(Qt::LayoutDirection dir) { m_layoutDirection = dir; }
+
   Qt::LayoutDirection layoutDirection() const { return m_layoutDirection; }
 
   const QString& outDir() const { return m_outDir; }

--- a/src/core/ProjectPages.cpp
+++ b/src/core/ProjectPages.cpp
@@ -72,6 +72,14 @@ Qt::LayoutDirection ProjectPages::layoutDirection() const {
   }
 }
 
+void ProjectPages::setLayoutDirection(const Qt::LayoutDirection dir) {
+  {
+    QMutexLocker locker(&m_mutex);
+    initSubPagesInOrder(dir);
+  }
+  emit modified();
+}
+
 void ProjectPages::initSubPagesInOrder(const Qt::LayoutDirection layoutDirection) {
   if (layoutDirection == Qt::LeftToRight) {
     m_subPagesInOrder[0] = PageId::LEFT_PAGE;

--- a/src/core/ProjectPages.h
+++ b/src/core/ProjectPages.h
@@ -48,6 +48,11 @@ class ProjectPages : public QObject {
 
   Qt::LayoutDirection layoutDirection() const;
 
+  /**
+   * \brief Swap logical order of left/right sub-pages for two-page layouts (issue #62).
+   */
+  void setLayoutDirection(Qt::LayoutDirection dir);
+
   PageSequence toPageSequence(PageView view) const;
 
   void listRelinkablePaths(const VirtualFunction<void, const RelinkablePath&>& sink) const;

--- a/src/core/filters/deskew/ApplyDialog.cpp
+++ b/src/core/filters/deskew/ApplyDialog.cpp
@@ -33,25 +33,28 @@ ApplyDialog::ApplyDialog(QWidget* parent, const PageId& curPage, const PageSelec
 ApplyDialog::~ApplyDialog() = default;
 
 void ApplyDialog::onSubmit() {
+  const bool applyDeskew = applyDeskewCheckBox->isChecked();
+  const bool applyOblique = applyObliqueCheckBox->isChecked();
+
   std::set<PageId> pages;
   // thisPageRB is intentionally not handled.
   if (allPagesRB->isChecked()) {
     m_pages.selectAll().swap(pages);
-    emit appliedToAllPages(pages);
+    emit appliedToAllPages(pages, applyDeskew, applyOblique);
   } else if (thisPageAndFollowersRB->isChecked()) {
     m_pages.selectPagePlusFollowers(m_curPage).swap(pages);
-    emit appliedTo(pages);
+    emit appliedTo(pages, applyDeskew, applyOblique);
   } else if (selectedPagesRB->isChecked()) {
-    emit appliedTo(m_selectedPages);
+    emit appliedTo(m_selectedPages, applyDeskew, applyOblique);
   } else if (everyOtherRB->isChecked()) {
     m_pages.selectEveryOther(m_curPage).swap(pages);
-    emit appliedTo(pages);
+    emit appliedTo(pages, applyDeskew, applyOblique);
   } else if (thisEveryOtherRB->isChecked()) {
     m_pages.selectThisPageAndFollowingEveryOther(m_curPage).swap(pages);
-    emit appliedTo(pages);
+    emit appliedTo(pages, applyDeskew, applyOblique);
   } else if (everyOtherSelectedRB->isChecked()) {
     m_pages.selectEveryOtherInSubsetFromPage(m_curPage, m_selectedPages).swap(pages);
-    emit appliedTo(pages);
+    emit appliedTo(pages, applyDeskew, applyOblique);
   }
   accept();
 }  // ApplyDialog::onSubmit

--- a/src/core/filters/deskew/ApplyDialog.h
+++ b/src/core/filters/deskew/ApplyDialog.h
@@ -25,9 +25,9 @@ class ApplyDialog : public QDialog, private Ui::ApplyDialog {
 
  signals:
 
-  void appliedTo(const std::set<PageId>& pages);
+  void appliedTo(const std::set<PageId>& pages, bool applyDeskew, bool applyOblique);
 
-  void appliedToAllPages(const std::set<PageId>& pages);
+  void appliedToAllPages(const std::set<PageId>& pages, bool applyDeskew, bool applyOblique);
 
  private slots:
 

--- a/src/core/filters/deskew/ApplyDialog.ui
+++ b/src/core/filters/deskew/ApplyDialog.ui
@@ -140,6 +140,35 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="applyPartsGroupBox">
+     <property name="title">
+      <string>Apply parameters</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_apply_parts">
+      <item>
+       <widget class="QCheckBox" name="applyDeskewCheckBox">
+        <property name="text">
+         <string>Deskew angle and mode</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="applyObliqueCheckBox">
+        <property name="text">
+         <string>Oblique angle and mode</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/core/filters/deskew/CacheDrivenTask.cpp
+++ b/src/core/filters/deskew/CacheDrivenTask.cpp
@@ -27,7 +27,9 @@ void CacheDrivenTask::process(const PageInfo& pageInfo,
                               const ImageTransformation& xform) {
   const Dependencies deps(xform.preCropArea(), xform.preRotation());
   std::unique_ptr<Params> params(m_settings->getPageParams(pageInfo.id()));
-  if (!params || (!deps.matches(params->dependencies()) && (params->mode() == MODE_AUTO))) {
+  if (!params
+      || (!deps.matches(params->dependencies())
+          && ((params->mode() == MODE_AUTO) || (params->obliqueMode() == MODE_AUTO)))) {
     if (auto* thumbCol = dynamic_cast<ThumbnailCollector*>(collector)) {
       thumbCol->processThumbnail(std::unique_ptr<QGraphicsItem>(new IncompleteThumbnail(
           thumbCol->thumbnailCache(), thumbCol->maxLogicalThumbSize(), pageInfo.imageId(), xform)));

--- a/src/core/filters/deskew/OptionsWidget.cpp
+++ b/src/core/filters/deskew/OptionsWidget.cpp
@@ -6,9 +6,29 @@
 #include <utility>
 
 #include "ApplyDialog.h"
+#include "Params.h"
 #include "Settings.h"
 
 namespace deskew {
+namespace {
+
+Params mergeParamsForApply(const std::unique_ptr<Params>& existing,
+                           const OptionsWidget::UiData& cur,
+                           const bool applyDeskew,
+                           const bool applyOblique) {
+  const Dependencies deps(cur.dependencies());
+  if (!existing) {
+    return Params(applyDeskew ? cur.effectiveDeskewAngle() : 0.0, applyOblique ? cur.effectiveObliqueAngle() : 0.0,
+                  deps, applyDeskew ? cur.mode() : MODE_AUTO, applyOblique ? cur.obliqueMode() : MODE_AUTO);
+  }
+  return Params(applyDeskew ? cur.effectiveDeskewAngle() : existing->deskewAngle(),
+                applyOblique ? cur.effectiveObliqueAngle() : existing->obliqueAngle(), deps,
+                applyDeskew ? cur.mode() : existing->mode(),
+                applyOblique ? cur.obliqueMode() : existing->obliqueMode());
+}
+
+}  // namespace
+
 const double OptionsWidget::MAX_ANGLE = 45.0;
 
 OptionsWidget::OptionsWidget(std::shared_ptr<Settings> settings, const PageSelectionAccessor& pageSelectionAccessor)
@@ -31,20 +51,21 @@ void OptionsWidget::showDeskewDialog() {
   auto* dialog = new ApplyDialog(this, m_pageId, m_pageSelectionAccessor);
   dialog->setAttribute(Qt::WA_DeleteOnClose);
   dialog->setWindowTitle(tr("Apply Deskew"));
-  connect(dialog, SIGNAL(appliedTo(const std::set<PageId>&)), this, SLOT(appliedTo(const std::set<PageId>&)));
-  connect(dialog, SIGNAL(appliedToAllPages(const std::set<PageId>&)), this,
-          SLOT(appliedToAllPages(const std::set<PageId>&)));
+  connect(dialog, &ApplyDialog::appliedTo, this, &OptionsWidget::appliedTo);
+  connect(dialog, &ApplyDialog::appliedToAllPages, this, &OptionsWidget::appliedToAllPages);
   dialog->show();
 }
 
-void OptionsWidget::appliedTo(const std::set<PageId>& pages) {
-  if (pages.empty()) {
+void OptionsWidget::appliedTo(const std::set<PageId>& pages, const bool applyDeskew, const bool applyOblique) {
+  if (pages.empty() || (!applyDeskew && !applyOblique)) {
     return;
   }
 
-  const Params params(m_uiData.effectiveDeskewAngle(), m_uiData.effectiveObliqueAngle(), m_uiData.dependencies(),
-                      m_uiData.mode());
-  m_settings->setDegrees(pages, params);
+  for (const PageId& pageId : pages) {
+    std::unique_ptr<Params> existing(m_settings->getPageParams(pageId));
+    const Params merged(mergeParamsForApply(existing, m_uiData, applyDeskew, applyOblique));
+    m_settings->setPageParams(pageId, merged);
+  }
 
   if (pages.size() > 1) {
     emit invalidateAllThumbnails();
@@ -55,14 +76,18 @@ void OptionsWidget::appliedTo(const std::set<PageId>& pages) {
   }
 }
 
-void OptionsWidget::appliedToAllPages(const std::set<PageId>& pages) {
-  if (pages.empty()) {
+void OptionsWidget::appliedToAllPages(const std::set<PageId>& pages,
+                                      const bool applyDeskew,
+                                      const bool applyOblique) {
+  if (pages.empty() || (!applyDeskew && !applyOblique)) {
     return;
   }
 
-  const Params params(m_uiData.effectiveDeskewAngle(), m_uiData.effectiveObliqueAngle(), m_uiData.dependencies(),
-                      m_uiData.mode());
-  m_settings->setDegrees(pages, params);
+  for (const PageId& pageId : pages) {
+    std::unique_ptr<Params> existing(m_settings->getPageParams(pageId));
+    const Params merged(mergeParamsForApply(existing, m_uiData, applyDeskew, applyOblique));
+    m_settings->setPageParams(pageId, merged);
+  }
   emit invalidateAllThumbnails();
 }
 
@@ -80,8 +105,8 @@ void OptionsWidget::manualObliqueAngleSetExternally(const double degrees) {
   auto block = m_connectionManager.getScopedBlock();
 
   m_uiData.setEffectiveObliqueAngle(degrees);
-  m_uiData.setMode(MODE_MANUAL);
-  updateModeIndication(MODE_MANUAL);
+  m_uiData.setObliqueMode(MODE_MANUAL);
+  updateObliqueModeIndication(MODE_MANUAL);
   obliqueSpinBox->setValue(degrees);
   commitCurrentParams();
 
@@ -96,6 +121,8 @@ void OptionsWidget::preUpdateUI(const PageId& pageId) {
   autoBtn->setChecked(true);
   autoBtn->setEnabled(false);
   manualBtn->setEnabled(false);
+  obliqueAutoBtn->setEnabled(false);
+  obliqueManualBtn->setEnabled(false);
 }
 
 void OptionsWidget::postUpdateUI(const UiData& uiData) {
@@ -104,7 +131,10 @@ void OptionsWidget::postUpdateUI(const UiData& uiData) {
   m_uiData = uiData;
   autoBtn->setEnabled(true);
   manualBtn->setEnabled(true);
+  obliqueAutoBtn->setEnabled(true);
+  obliqueManualBtn->setEnabled(true);
   updateModeIndication(uiData.mode());
+  updateObliqueModeIndication(uiData.obliqueMode());
   setSpinBoxKnownState(degreesToSpinBox(uiData.effectiveDeskewAngle()));
   obliqueSpinBox->setValue(m_uiData.effectiveObliqueAngle());
 }
@@ -125,11 +155,26 @@ void OptionsWidget::spinBoxValueChanged(const double value) {
 void OptionsWidget::modeChanged(const bool autoMode) {
   if (autoMode) {
     m_uiData.setMode(MODE_AUTO);
-    m_uiData.setEffectiveObliqueAngle(0.0);  // Auto ==> Oblique = 0 (PR #108 feedback)
+    if (m_uiData.obliqueMode() == MODE_AUTO) {
+      m_uiData.setEffectiveObliqueAngle(0.0);
+    }
     m_settings->clearPageParams(m_pageId);
     emit reloadRequested();
   } else {
     m_uiData.setMode(MODE_MANUAL);
+    commitCurrentParams();
+  }
+}
+
+void OptionsWidget::obliqueModeChanged(const bool autoMode) {
+  if (autoMode) {
+    m_uiData.setObliqueMode(MODE_AUTO);
+    m_uiData.setEffectiveObliqueAngle(0.0);
+    obliqueSpinBox->setValue(0.0);
+    commitCurrentParams();
+    emit reloadRequested();
+  } else {
+    m_uiData.setObliqueMode(MODE_MANUAL);
     commitCurrentParams();
   }
 }
@@ -144,6 +189,16 @@ void OptionsWidget::updateModeIndication(const AutoManualMode mode) {
   }
 }
 
+void OptionsWidget::updateObliqueModeIndication(const AutoManualMode mode) {
+  auto block = m_connectionManager.getScopedBlock();
+
+  if (mode == MODE_AUTO) {
+    obliqueAutoBtn->setChecked(true);
+  } else {
+    obliqueManualBtn->setChecked(true);
+  }
+}
+
 void OptionsWidget::setSpinBoxUnknownState() {
   auto block = m_connectionManager.getScopedBlock();
 
@@ -153,6 +208,8 @@ void OptionsWidget::setSpinBoxUnknownState() {
   angleSpinBox->setEnabled(false);
   obliqueSpinBox->setValue(0.0);
   obliqueSpinBox->setEnabled(false);
+  obliqueAutoBtn->setEnabled(false);
+  obliqueManualBtn->setEnabled(false);
 }
 
 void OptionsWidget::setSpinBoxKnownState(const double angle) {
@@ -165,11 +222,13 @@ void OptionsWidget::setSpinBoxKnownState(const double angle) {
   angleSpinBox->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
   angleSpinBox->setEnabled(true);
   obliqueSpinBox->setEnabled(true);
+  obliqueAutoBtn->setEnabled(true);
+  obliqueManualBtn->setEnabled(true);
 }
 
 void OptionsWidget::commitCurrentParams() {
   Params params(m_uiData.effectiveDeskewAngle(), m_uiData.effectiveObliqueAngle(), m_uiData.dependencies(),
-                m_uiData.mode());
+                m_uiData.mode(), m_uiData.obliqueMode());
   m_settings->setPageParams(m_pageId, params);
 }
 
@@ -200,8 +259,8 @@ void OptionsWidget::obliqueSpinBoxValueChanged(double value) {
 
   m_uiData.setEffectiveObliqueAngle(value);
   if (value != 0.0) {
-    m_uiData.setMode(MODE_MANUAL);  // Oblique != 0 ==> Mode = Manual (PR #108 feedback)
-    updateModeIndication(MODE_MANUAL);
+    m_uiData.setObliqueMode(MODE_MANUAL);
+    updateObliqueModeIndication(MODE_MANUAL);
   }
   commitCurrentParams();
   emit manualObliqueAngleSet(value);
@@ -212,6 +271,7 @@ void OptionsWidget::setupUiConnections() {
   CONNECT(angleSpinBox, SIGNAL(valueChanged(double)), this, SLOT(spinBoxValueChanged(double)));
   CONNECT(obliqueSpinBox, SIGNAL(valueChanged(double)), this, SLOT(obliqueSpinBoxValueChanged(double)));
   CONNECT(autoBtn, SIGNAL(toggled(bool)), this, SLOT(modeChanged(bool)));
+  CONNECT(obliqueAutoBtn, SIGNAL(toggled(bool)), this, SLOT(obliqueModeChanged(bool)));
   CONNECT(topEdgeCheckBox, SIGNAL(toggled(bool)), this, SLOT(topEdgeToggled(bool)));
   CONNECT(applyDeskewBtn, SIGNAL(clicked()), this, SLOT(showDeskewDialog()));
 }
@@ -220,7 +280,8 @@ void OptionsWidget::setupUiConnections() {
 
 /*========================== OptionsWidget::UiData =========================*/
 
-OptionsWidget::UiData::UiData() : m_effDeskewAngle(0.0), m_effObliqueAngle(0.0), m_mode(MODE_AUTO) {}
+OptionsWidget::UiData::UiData()
+    : m_effDeskewAngle(0.0), m_effObliqueAngle(0.0), m_mode(MODE_AUTO), m_obliqueMode(MODE_AUTO) {}
 
 OptionsWidget::UiData::~UiData() = default;
 }  // namespace deskew

--- a/src/core/filters/deskew/OptionsWidget.cpp
+++ b/src/core/filters/deskew/OptionsWidget.cpp
@@ -76,9 +76,7 @@ void OptionsWidget::appliedTo(const std::set<PageId>& pages, const bool applyDes
   }
 }
 
-void OptionsWidget::appliedToAllPages(const std::set<PageId>& pages,
-                                      const bool applyDeskew,
-                                      const bool applyOblique) {
+void OptionsWidget::appliedToAllPages(const std::set<PageId>& pages, const bool applyDeskew, const bool applyOblique) {
   if (pages.empty() || (!applyDeskew && !applyOblique)) {
     return;
   }

--- a/src/core/filters/deskew/OptionsWidget.h
+++ b/src/core/filters/deskew/OptionsWidget.h
@@ -46,11 +46,16 @@ class OptionsWidget : public FilterOptionsWidget, private Ui::OptionsWidget {
 
     AutoManualMode mode() const;
 
+    void setObliqueMode(AutoManualMode mode);
+
+    AutoManualMode obliqueMode() const;
+
    private:
     double m_effDeskewAngle;
     double m_effObliqueAngle;
     Dependencies m_deps;
     AutoManualMode m_mode;
+    AutoManualMode m_obliqueMode;
   };
 
 
@@ -83,16 +88,20 @@ class OptionsWidget : public FilterOptionsWidget, private Ui::OptionsWidget {
 
   void modeChanged(bool autoMode);
 
+  void obliqueModeChanged(bool autoMode);
+
   void topEdgeToggled(bool checked);
 
   void showDeskewDialog();
 
-  void appliedTo(const std::set<PageId>& pages);
+  void appliedTo(const std::set<PageId>& pages, bool applyDeskew, bool applyOblique);
 
-  void appliedToAllPages(const std::set<PageId>& pages);
+  void appliedToAllPages(const std::set<PageId>& pages, bool applyDeskew, bool applyOblique);
 
  private:
   void updateModeIndication(AutoManualMode mode);
+
+  void updateObliqueModeIndication(AutoManualMode mode);
 
   void setSpinBoxUnknownState();
 
@@ -148,6 +157,14 @@ inline void OptionsWidget::UiData::setMode(const AutoManualMode mode) {
 
 inline AutoManualMode OptionsWidget::UiData::mode() const {
   return m_mode;
+}
+
+inline void OptionsWidget::UiData::setObliqueMode(const AutoManualMode mode) {
+  m_obliqueMode = mode;
+}
+
+inline AutoManualMode OptionsWidget::UiData::obliqueMode() const {
+  return m_obliqueMode;
 }
 }  // namespace deskew
 

--- a/src/core/filters/deskew/OptionsWidget.ui
+++ b/src/core/filters/deskew/OptionsWidget.ui
@@ -137,6 +137,52 @@
        </layout>
       </item>
       <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_oblique_mode">
+        <item>
+         <widget class="QLabel" name="obliqueModeLabel">
+          <property name="text">
+           <string>Oblique mode</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="obliqueAutoBtn">
+          <property name="text">
+           <string>Auto</string>
+          </property>
+          <property name="toolTip">
+           <string>Automatically estimate oblique (shear) correction.</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="autoExclusive">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="obliqueManualBtn">
+          <property name="text">
+           <string>Manual</string>
+          </property>
+          <property name="toolTip">
+           <string>Keep the oblique angle set in the spin box.</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="autoExclusive">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <spacer name="horizontalSpacer_9">

--- a/src/core/filters/deskew/Params.cpp
+++ b/src/core/filters/deskew/Params.cpp
@@ -11,19 +11,29 @@
 using namespace foundation;
 
 namespace deskew {
-Params::Params(const double deskewAngleDeg, const Dependencies& deps, const AutoManualMode mode)
-    : m_rotation{deskewAngleDeg, mode}, m_oblique{0.0}, m_deps(deps) {}
+Params::Params(const double deskewAngleDeg, const Dependencies& deps, const AutoManualMode deskewMode)
+    : m_rotation{deskewAngleDeg, deskewMode}, m_oblique{0.0, MODE_AUTO}, m_deps(deps) {}
+
+Params::Params(const double deskewAngleDeg,
+               const double obliqueDeg,
+               const Dependencies& deps,
+               const AutoManualMode deskewMode,
+               const AutoManualMode obliqueMode)
+    : m_rotation{deskewAngleDeg, deskewMode}, m_oblique{obliqueDeg, obliqueMode}, m_deps(deps) {}
 
 Params::Params(const double deskewAngleDeg,
                const double obliqueDeg,
                const Dependencies& deps,
                const AutoManualMode mode)
-    : m_rotation{deskewAngleDeg, mode}, m_oblique{obliqueDeg}, m_deps(deps) {}
+    : m_rotation{deskewAngleDeg, mode}, m_oblique{obliqueDeg, mode}, m_deps(deps) {}
 
 Params::Params(const QDomElement& deskewEl)
     : m_rotation{deskewEl.attribute("angle").toDouble(),
                  deskewEl.attribute("mode") == "manual" ? MODE_MANUAL : MODE_AUTO},
-      m_oblique{deskewEl.attribute("oblique").toDouble()},
+      m_oblique{deskewEl.attribute("oblique").toDouble(),
+                deskewEl.hasAttribute("oblique-mode")
+                    ? (deskewEl.attribute("oblique-mode") == "manual" ? MODE_MANUAL : MODE_AUTO)
+                    : (deskewEl.attribute("mode") == "manual" ? MODE_MANUAL : MODE_AUTO)},
       m_deps(deskewEl.namedItem("dependencies").toElement()) {}
 
 Params::~Params() = default;
@@ -33,6 +43,7 @@ QDomElement Params::toXml(QDomDocument& doc, const QString& name) const {
   el.setAttribute("mode", m_rotation.mode == MODE_AUTO ? "auto" : "manual");
   el.setAttribute("angle", Utils::doubleToString(m_rotation.angle));
   el.setAttribute("oblique", Utils::doubleToString(m_oblique.obliqueAngle));
+  el.setAttribute("oblique-mode", m_oblique.mode == MODE_AUTO ? "auto" : "manual");
   el.appendChild(m_deps.toXml(doc, "dependencies"));
   return el;
 }

--- a/src/core/filters/deskew/Params.h
+++ b/src/core/filters/deskew/Params.h
@@ -25,17 +25,25 @@ struct RotationParams {
   AutoManualMode mode = MODE_AUTO;
 };
 
-/** Oblique (shear) angle in degrees. */
+/** Oblique (shear) angle in degrees and its own auto/manual mode (issue #117). */
 struct ObliqueParams {
   double obliqueAngle = 0.0;
+  AutoManualMode mode = MODE_AUTO;
 };
 
 class Params {
  public:
   // Member-wise copying is OK.
 
-  Params(double deskewAngleDeg, const Dependencies& deps, AutoManualMode mode);
+  Params(double deskewAngleDeg, const Dependencies& deps, AutoManualMode deskewMode);
 
+  Params(double deskewAngleDeg,
+         double obliqueDeg,
+         const Dependencies& deps,
+         AutoManualMode deskewMode,
+         AutoManualMode obliqueMode);
+
+  /** Legacy: oblique mode matches \p mode (coupled deskew/oblique). */
   Params(double deskewAngleDeg, double obliqueDeg, const Dependencies& deps, AutoManualMode mode);
 
   explicit Params(const QDomElement& deskewEl);
@@ -49,6 +57,8 @@ class Params {
   const Dependencies& dependencies() const;
 
   AutoManualMode mode() const;
+
+  AutoManualMode obliqueMode() const;
 
   QDomElement toXml(QDomDocument& doc, const QString& name) const;
 
@@ -73,6 +83,10 @@ inline const Dependencies& Params::dependencies() const {
 
 inline AutoManualMode Params::mode() const {
   return m_rotation.mode;
+}
+
+inline AutoManualMode Params::obliqueMode() const {
+  return m_oblique.mode;
 }
 }  // namespace deskew
 

--- a/src/core/filters/deskew/Task.cpp
+++ b/src/core/filters/deskew/Task.cpp
@@ -102,8 +102,10 @@ FilterResultPtr Task::process(const TaskStatus& status, FilterData data) {
       uiData.setEffectiveDeskewAngle(params->deskewAngle());
       uiData.setEffectiveObliqueAngle(params->obliqueAngle());
       uiData.setMode(params->mode());
+      uiData.setObliqueMode(params->obliqueMode());
 
-      Params newParams(uiData.effectiveDeskewAngle(), uiData.effectiveObliqueAngle(), deps, uiData.mode());
+      Params newParams(uiData.effectiveDeskewAngle(), uiData.effectiveObliqueAngle(), deps, uiData.mode(),
+                       uiData.obliqueMode());
       m_settings->setPageParams(m_pageId, newParams);
     }
   }
@@ -142,6 +144,7 @@ FilterResultPtr Task::process(const TaskStatus& status, FilterData data) {
         uiData.setEffectiveDeskewAngle(0);
       }
       uiData.setMode(MODE_AUTO);
+      uiData.setObliqueMode(MODE_AUTO);
 
       // Find oblique on the deskewed (horizontal) mask for better accuracy (PR #110 feedback).
       BinaryImage horizontalMask;
@@ -174,7 +177,8 @@ FilterResultPtr Task::process(const TaskStatus& status, FilterData data) {
         uiData.setEffectiveObliqueAngle(-*obliqueDeg);
       }
 
-      Params newParams(uiData.effectiveDeskewAngle(), uiData.effectiveObliqueAngle(), deps, uiData.mode());
+      Params newParams(uiData.effectiveDeskewAngle(), uiData.effectiveObliqueAngle(), deps, uiData.mode(),
+                       uiData.obliqueMode());
       m_settings->setPageParams(m_pageId, newParams);
 
       status.throwIfCancelled();

--- a/src/core/filters/deskew/Utils.cpp
+++ b/src/core/filters/deskew/Utils.cpp
@@ -14,5 +14,5 @@ Params Utils::buildDefaultParams() {
   const DefaultParams& defaultParams = DefaultParamsProvider::getInstance().getParams();
   const DefaultParams::DeskewParams& deskewParams = defaultParams.getDeskewParams();
 
-  return Params(deskewParams.getDeskewAngleDeg(), 0.0, Dependencies(), deskewParams.getMode());
+  return Params(deskewParams.getDeskewAngleDeg(), 0.0, Dependencies(), deskewParams.getMode(), MODE_AUTO);
 }

--- a/src/core/filters/select_content/Task.cpp
+++ b/src/core/filters/select_content/Task.cpp
@@ -93,6 +93,8 @@ FilterResultPtr Task::process(const TaskStatus& status, const FilterData& data) 
     QRectF contentRect(newParams.contentRect());
 
     if (needUpdatePageBox) {
+      const QRectF oldPageRect(pageRect);
+
       if (newParams.pageDetectionMode() == MODE_AUTO) {
         pageRect
             = PageFinder::findPageBox(status, data, newParams.isFineTuningEnabled(), m_settings->pageDetectionBox(),
@@ -105,8 +107,15 @@ FilterResultPtr Task::process(const TaskStatus& status, const FilterData& data) 
         pageRect = data.xform().resultingRect();
       }
 
-      // When offcut/page outline changes, preserve manual content box by clipping to new page rect (issue #90).
-      if (contentRect.isValid() && (contentRect.intersected(pageRect) != contentRect)) {
+      // When offcut/page outline changes, keep manual content aligned with page motion (issue #90).
+      if (newParams.contentDetectionMode() == MODE_MANUAL && contentRect.isValid() && oldPageRect.isValid()
+          && pageRect.isValid()) {
+        contentRect.translate(pageRect.center() - oldPageRect.center());
+        contentRect &= pageRect;
+        if (!contentRect.isValid()) {
+          needUpdateContentBox = true;
+        }
+      } else if (contentRect.isValid() && (contentRect.intersected(pageRect) != contentRect)) {
         if (newParams.contentDetectionMode() == MODE_MANUAL) {
           contentRect = contentRect.intersected(pageRect);
         } else {
@@ -122,6 +131,12 @@ FilterResultPtr Task::process(const TaskStatus& status, const FilterData& data) 
         contentRect = ContentBoxFinder::findContentBox(status, data, pageRect, m_dbg.get());
       } else if (newParams.contentDetectionMode() == MODE_DISABLED) {
         contentRect = pageRect;
+      } else if (newParams.contentDetectionMode() == MODE_MANUAL) {
+        if (contentRect.isValid() && pageRect.isValid()) {
+          contentRect &= pageRect;
+        } else {
+          contentRect = QRectF();
+        }
       }
 
       if (contentRect.isValid()) {

--- a/src/core/tests/TestDeskewParams.cpp
+++ b/src/core/tests/TestDeskewParams.cpp
@@ -32,6 +32,7 @@ BOOST_AUTO_TEST_CASE(params_oblique_roundtrip_xml) {
   BOOST_CHECK_CLOSE(restored.deskewAngle(), deskewDeg, 1e-6);
   BOOST_CHECK_CLOSE(restored.obliqueAngle(), obliqueDeg, 1e-6);
   BOOST_CHECK(restored.mode() == MODE_MANUAL);
+  BOOST_CHECK(restored.obliqueMode() == MODE_MANUAL);
 }
 
 BOOST_AUTO_TEST_CASE(params_zero_oblique_roundtrip_xml) {
@@ -48,6 +49,21 @@ BOOST_AUTO_TEST_CASE(params_zero_oblique_roundtrip_xml) {
   BOOST_CHECK_CLOSE(restored.deskewAngle(), deskewDeg, 1e-6);
   BOOST_CHECK_CLOSE(restored.obliqueAngle(), 0.0, 1e-6);
   BOOST_CHECK(restored.mode() == MODE_AUTO);
+  BOOST_CHECK(restored.obliqueMode() == MODE_AUTO);
+}
+
+BOOST_AUTO_TEST_CASE(params_independent_oblique_mode_xml) {
+  const Dependencies deps;
+  const Params original(1.0, 2.0, deps, MODE_MANUAL, MODE_AUTO);
+
+  QDomDocument doc;
+  const QDomElement el = original.toXml(doc, "deskew-params");
+  doc.appendChild(el);
+
+  const Params restored(doc.documentElement());
+
+  BOOST_CHECK(restored.mode() == MODE_MANUAL);
+  BOOST_CHECK(restored.obliqueMode() == MODE_AUTO);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
Single integration branch addressing P0 tracker items in one PR (can be split on request).

### #97 Wayland (Qt5)
- Default `QT_QPA_PLATFORM=xcb` when `XDG_SESSION_TYPE=wayland` and platform not set.
- Opt-out: `SCANTAILOR_NO_XCB_FALLBACK=1`. README updated.

### #75 Multi-monitor context menus
- `QMenu` parent set to thumbnail view for correct placement.

### #90 Manual content box vs page/offcut changes
- Translate manual `contentRect` with page rect center shift, then clip; fallback to content refresh if invalid.

### #62 Two-page spread reading order
- `ProjectPages::setLayoutDirection` + Tools action **Reverse two-page spread order**; `OutputFileNameGenerator` updated with layout direction.

### #117 Deskew vs oblique parameter model
- Separate **oblique** auto/manual (`oblique-mode` in XML), UI row **Oblique mode**, **Apply To…** checkboxes (deskew / oblique) with per-page merge.
- `CacheDrivenTask`: incomplete thumbnail when oblique is auto and deps mismatch.

## Testing
- `cmake --build build`, `core_tests --run_test=DeskewParamsTestSuite`

## Feedback requested
Please try real workflows (especially #90 offcut round-trip, #62 Japanese-style order, #117 copy/apply combinations) and report on this PR.