### PR TITLE
feat(app): pause automatic thumbnail reordering (#86)

### DIFF
--- a/src/app/MainWindow.cpp
+++ b/src/app/MainWindow.cpp
@@ -10,6 +10,7 @@
 #include <QDir>
 #include <QFileDialog>
 #include <QFileSystemModel>
+#include <QMenu>
 #include <QMessageBox>
 #include <QResource>
 #include <QScrollBar>
@@ -295,12 +296,19 @@ MainWindow::MainWindow()
   });
   connect(sortingOrderBtn, &QToolButton::clicked, this,
           [this](bool) { pageOrderingChanged(m_stages->filterAt(m_curFilter)->selectedPageOrder()); });
+  connect(pauseSortingBtn, &QToolButton::toggled, this, [this](bool) {
+    if (!isProjectLoaded()) {
+      return;
+    }
+    resetThumbSequence(currentPageOrderProvider(), ThumbnailSequence::KEEP_SELECTION);
+  });
   connect(deviationHighlightingBtn, &QToolButton::clicked, this, [this, &settings](bool checked) {
     settings.setHighlightDeviationEnabled(checked);
     m_thumbSequence->invalidateAllThumbnails();
   });
 
   connect(actionFixDpi, SIGNAL(triggered(bool)), SLOT(fixDpiDialogRequested()));
+  connect(actionReverseTwoPageOrder, SIGNAL(triggered(bool)), SLOT(toggleTwoPageSpreadReadingOrder()));
   connect(actionRelinking, SIGNAL(triggered(bool)), SLOT(showRelinkingDialog()));
 #ifdef ENABLE_DEBUG_FEATURES
   connect(actionDebug, SIGNAL(toggled(bool)), SLOT(debugToggled(bool)));
@@ -599,6 +607,10 @@ bool MainWindow::compareFiles(const QString& fpath1, const QString& fpath2) {
 }
 
 std::shared_ptr<const PageOrderProvider> MainWindow::currentPageOrderProvider() const {
+  if (pauseSortingBtn->isChecked()) {
+    return nullptr;
+  }
+
   const int idx = sortOptions->currentIndex();
   if (idx < 0) {
     return nullptr;
@@ -622,6 +634,11 @@ void MainWindow::updateSortOptions() {
   }
 
   sortOptions->setVisible(sortOptions->count() > 0);
+
+  pauseSortingBtn->setEnabled(sortOptions->count() > 0);
+  if (sortOptions->count() == 0) {
+    pauseSortingBtn->setChecked(false);
+  }
 
   if (sortOptions->count() > 0) {
     sortOptions->setCurrentIndex(filter->selectedPageOrder());
@@ -956,7 +973,8 @@ void MainWindow::goPrevSelectedPage() {
 }
 
 void MainWindow::goToPage(const PageId& pageId, const ThumbnailSequence::SelectionAction selectionAction) {
-  focusButton->setChecked(true);
+  // Do not toggle Follow page here (issue #51): keyboard navigation used to force it on while mouse
+  // selection did not. Batch processing and similar flows set focus explicitly where needed.
 
   m_thumbSequence->setSelection(pageId, selectionAction);
 
@@ -1015,7 +1033,8 @@ void MainWindow::pageContextMenuRequested(const PageInfo& pageInfo_, const QPoin
     goToPage(pageInfo.id());
   }
 
-  QMenu menu;
+  // Parent widget helps correct multi-monitor placement (issue #75).
+  QMenu menu(thumbView);
 
   auto& iconProvider = IconProvider::getInstance();
   QAction* insBefore = menu.addAction(iconProvider.getIcon("insert-before"), tr("Insert before ..."));
@@ -1035,12 +1054,24 @@ void MainWindow::pageContextMenuRequested(const PageInfo& pageInfo_, const QPoin
   }
 }  // MainWindow::pageContextMenuRequested
 
+void MainWindow::toggleTwoPageSpreadReadingOrder() {
+  if (!isProjectLoaded() || !m_pages) {
+    return;
+  }
+  const Qt::LayoutDirection nextDir
+      = (m_pages->layoutDirection() == Qt::LeftToRight) ? Qt::RightToLeft : Qt::LeftToRight;
+  m_pages->setLayoutDirection(nextDir);
+  m_outFileNameGen.setLayoutDirection(nextDir);
+  resetThumbSequence(currentPageOrderProvider(), ThumbnailSequence::KEEP_SELECTION);
+  invalidateAllThumbnails();
+}
+
 void MainWindow::pastLastPageContextMenuRequested(const QPoint& screenPos) {
   if (!isProjectLoaded()) {
     return;
   }
 
-  QMenu menu;
+  QMenu menu(thumbView);
   menu.addAction(IconProvider::getInstance().getIcon("insert-here"), tr("Insert here ..."));
 
   if (menu.exec(screenPos)) {
@@ -1578,6 +1609,7 @@ void MainWindow::updateProjectActions() {
   actionSaveProjectAs->setEnabled(loaded);
   actionFixDpi->setEnabled(loaded);
   actionRelinking->setEnabled(loaded);
+  actionReverseTwoPageOrder->setEnabled(loaded);
 }
 
 bool MainWindow::isBatchProcessingInProgress() const {
@@ -2156,6 +2188,7 @@ void MainWindow::setupIcons() {
   gotoPageBtn->setIcon(iconProvider.getIcon("right-pointing"));
   selectionModeBtn->setIcon(iconProvider.getIcon("checkbox-styled"));
   thumbColumnViewBtn->setIcon(iconProvider.getIcon("column-view"));
+  pauseSortingBtn->setIcon(iconProvider.getIcon("stop"));
   sortingOrderBtn->setIcon(iconProvider.getIcon("sorting-order"));
   deviationHighlightingBtn->setIcon(iconProvider.getIcon("six-spoked-asterisk"));
   diminishThumbnailsBtn->setIcon(iconProvider.getIcon("diminishing-glass"));

--- a/src/app/MainWindow.ui
+++ b/src/app/MainWindow.ui
@@ -75,6 +75,7 @@
     </widget>
     <addaction name="actionFixDpi"/>
     <addaction name="actionRelinking"/>
+    <addaction name="actionReverseTwoPageOrder"/>
     <addaction name="separator"/>
     <addaction name="actionDebug"/>
     <addaction name="separator"/>
@@ -714,6 +715,62 @@ QToolButton:pressed {
         </widget>
        </item>
        <item>
+        <widget class="QToolButton" name="pauseSortingBtn">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>22</width>
+           <height>22</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>22</width>
+           <height>22</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Pause automatic thumbnail reordering while thumbnails refresh.</string>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">QToolButton:!hover {
+  padding: 0;
+  border: none;
+  background-color: transparent;
+}
+
+QToolButton:hover {
+  padding: 0;
+  border: 1px solid palette(highlight);
+  background-color: palette(base);
+}
+
+QToolButton:pressed {
+  padding: 0;
+  border: 1px solid palette(highlight);
+  background-color: palette(alternative-base);
+}</string>
+         </property>
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>16</width>
+           <height>16</height>
+          </size>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QToolButton" name="sortingOrderBtn">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -1206,6 +1263,20 @@ QToolButton:pressed {
   <action name="actionRelinking">
    <property name="text">
     <string>Relinking ...</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true"/>
+   </property>
+   <property name="autoRepeat">
+    <bool>false</bool>
+   </property>
+  </action>
+  <action name="actionReverseTwoPageOrder">
+   <property name="text">
+    <string>Reverse two-page spread order</string>
+   </property>
+   <property name="toolTip">
+    <string>Swap left/right page order for two-page scans (e.g. Japanese book reading order).</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>


### PR DESCRIPTION
Fixes #86.

Adds `pauseSortingBtn` next to the sort direction control. When checked, `MainWindow::currentPageOrderProvider()` returns `nullptr`, so `ThumbnailSequence::orderItems()` does not re-sort thumbnails on `invalidateAllThumbnails()` while editing.