### PR TITLE
feat(page_layout): lock aggregate size for match-size workflow (#85)

### DIFF
--- a/src/core/filters/page_layout/OptionsWidget.cpp
+++ b/src/core/filters/page_layout/OptionsWidget.cpp
@@ -82,6 +82,7 @@ void OptionsWidget::preUpdateUI(const PageInfo& pageInfo, const Margins& margins
   }
 
   alignWithOthersCB->setChecked(!alignment.isNull());
+  freezeAggregateHardSizeCb->setChecked(m_settings->isAggregateHardSizeFrozen());
 
   if (alignment.horizontal() == Alignment::HAUTO) {
     hAlignmentModeCB->setCurrentIndex(0);
@@ -380,6 +381,11 @@ void OptionsWidget::matchSizeToAllPages() {
   emit aggregateHardSizeChanged();
 }
 
+void OptionsWidget::freezeAggregateHardSizeToggled(const bool checked) {
+  m_settings->setAggregateHardSizeFrozen(checked);
+  emit aggregateHardSizeChanged();
+}
+
 void OptionsWidget::updateMarginsDisplay() {
   auto block = m_connectionManager.getScopedBlock();
 
@@ -448,6 +454,7 @@ void OptionsWidget::setupUiConnections() {
   CONNECT(alignWithOthersCB, SIGNAL(toggled(bool)), this, SLOT(alignWithOthersToggled()));
   CONNECT(applyAlignmentBtn, SIGNAL(clicked()), this, SLOT(showApplyAlignmentDialog()));
   CONNECT(matchSizeToAllBtn, SIGNAL(clicked()), this, SLOT(matchSizeToAllPages()));
+  CONNECT(freezeAggregateHardSizeCb, SIGNAL(clicked(bool)), this, SLOT(freezeAggregateHardSizeToggled(bool)));
   for (const auto& kv : m_alignmentByButton) {
     CONNECT(kv.first, SIGNAL(clicked()), this, SLOT(alignmentButtonClicked()));
   }

--- a/src/core/filters/page_layout/OptionsWidget.h
+++ b/src/core/filters/page_layout/OptionsWidget.h
@@ -89,6 +89,8 @@ class OptionsWidget : public FilterOptionsWidget, public UnitsListener, private 
 
   void matchSizeToAllPages();
 
+  void freezeAggregateHardSizeToggled(bool checked);
+
   void onFixDpiClicked();
 
   void applyMargins(const std::set<PageId>& pages,

--- a/src/core/filters/page_layout/OptionsWidget.ui
+++ b/src/core/filters/page_layout/OptionsWidget.ui
@@ -718,6 +718,16 @@ QToolButton:pressed {
        </layout>
       </item>
       <item>
+       <widget class="QCheckBox" name="freezeAggregateHardSizeCb">
+        <property name="toolTip">
+         <string>Keep the aggregate page size used for matching fixed while you switch pages, so the reference dimensions do not jump.</string>
+        </property>
+        <property name="text">
+         <string>Lock aggregate size for matching</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
          <spacer name="horizontalSpacer_11">

--- a/src/core/filters/page_layout/Settings.cpp
+++ b/src/core/filters/page_layout/Settings.cpp
@@ -14,6 +14,7 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index_container.hpp>
+#include <optional>
 #include <utility>
 
 #include "AbstractRelinker.h"
@@ -146,7 +147,13 @@ class Settings::Impl {
 
   QSizeF getAggregateHardSizeMMLocked() const;
 
+  QSizeF computeAggregateHardSizeMMLocked() const;
+
   QSizeF getAggregateHardSizeMM(const PageId& pageId, const QSizeF& hardSizeMm, const Alignment& alignment) const;
+
+  void setAggregateHardSizeFrozen(bool frozen);
+
+  bool isAggregateHardSizeFrozen() const;
 
   bool isPageAutoMarginsEnabled(const PageId& pageId);
 
@@ -199,6 +206,8 @@ class Settings::Impl {
   DeviationProvider<PageId> m_deviationProvider;
   std::vector<Guide> m_guides;
   bool m_showMiddleRect;
+
+  std::optional<QSizeF> m_frozenAggregateHardSizeMm;
 };
 
 
@@ -274,6 +283,14 @@ QSizeF Settings::getAggregateHardSizeMM(const PageId& pageId,
                                         const QSizeF& hardSizeMm,
                                         const Alignment& alignment) const {
   return m_impl->getAggregateHardSizeMM(pageId, hardSizeMm, alignment);
+}
+
+void Settings::setAggregateHardSizeFrozen(const bool frozen) {
+  m_impl->setAggregateHardSizeFrozen(frozen);
+}
+
+bool Settings::isAggregateHardSizeFrozen() const {
+  return m_impl->isAggregateHardSizeFrozen();
 }
 
 bool Settings::isPageAutoMarginsEnabled(const PageId& pageId) {
@@ -368,6 +385,7 @@ void Settings::Impl::clear() {
   const QMutexLocker locker(&m_mutex);
   m_items.clear();
   m_deviationProvider.clear();
+  m_frozenAggregateHardSizeMm.reset();
 }
 
 void Settings::Impl::performRelinking(const AbstractRelinker& relinker) {
@@ -586,7 +604,7 @@ QSizeF Settings::Impl::getAggregateHardSizeMM() const {
   return getAggregateHardSizeMMLocked();
 }
 
-QSizeF Settings::Impl::getAggregateHardSizeMMLocked() const {
+QSizeF Settings::Impl::computeAggregateHardSizeMMLocked() const {
   if (m_items.empty()) {
     return QSizeF(0.0, 0.0);
   }
@@ -599,14 +617,38 @@ QSizeF Settings::Impl::getAggregateHardSizeMMLocked() const {
   return QSizeF(width, height);
 }
 
+QSizeF Settings::Impl::getAggregateHardSizeMMLocked() const {
+  if (m_frozenAggregateHardSizeMm) {
+    return *m_frozenAggregateHardSizeMm;
+  }
+  return computeAggregateHardSizeMMLocked();
+}
+
+void Settings::Impl::setAggregateHardSizeFrozen(const bool frozen) {
+  const QMutexLocker locker(&m_mutex);
+  if (frozen) {
+    m_frozenAggregateHardSizeMm = computeAggregateHardSizeMMLocked();
+  } else {
+    m_frozenAggregateHardSizeMm.reset();
+  }
+}
+
+bool Settings::Impl::isAggregateHardSizeFrozen() const {
+  const QMutexLocker locker(&m_mutex);
+  return m_frozenAggregateHardSizeMm.has_value();
+}
+
 QSizeF Settings::Impl::getAggregateHardSizeMM(const PageId& pageId,
                                               const QSizeF& hardSizeMm,
                                               const Alignment& alignment) const {
-  if (alignment.isNull()) {
-    return getAggregateHardSizeMM();
+  const QMutexLocker locker(&m_mutex);
+  if (m_frozenAggregateHardSizeMm) {
+    return *m_frozenAggregateHardSizeMm;
   }
 
-  const QMutexLocker locker(&m_mutex);
+  if (alignment.isNull()) {
+    return computeAggregateHardSizeMMLocked();
+  }
 
   if (m_items.empty()) {
     return QSizeF(0.0, 0.0);

--- a/src/core/filters/page_layout/Settings.h
+++ b/src/core/filters/page_layout/Settings.h
@@ -141,6 +141,15 @@ class Settings {
    */
   QSizeF getAggregateHardSizeMM(const PageId& pageId, const QSizeF& hardSizeMm, const Alignment& alignment) const;
 
+  /**
+   * \brief When frozen, getAggregateHardSizeMM() returns a fixed reference size
+   *        until unfrozen, so the "match size" target does not change when
+   *        switching pages.
+   */
+  void setAggregateHardSizeFrozen(bool frozen);
+
+  bool isAggregateHardSizeFrozen() const;
+
   bool isPageAutoMarginsEnabled(const PageId& pageId);
 
   void setPageAutoMarginsEnabled(const PageId& pageId, bool state);


### PR DESCRIPTION
Fixes #85.

- `Settings`: optional frozen aggregate hard size (`setAggregateHardSizeFrozen` / `isAggregateHardSizeFrozen`) applied in aggregate queries without deadlocking the mutex.
- Margins panel: **Lock aggregate size for matching** checkbox updates the frozen reference and refreshes the layout view.