### PR TITLE
docs(page_split): note scope for extended offcut guides (#91)

### DIFF
--- a/src/core/filters/page_split/PageLayout.h
+++ b/src/core/filters/page_split/PageLayout.h
@@ -18,6 +18,11 @@ class QDomDocument;
 
 namespace page_split {
 /**
+ * GitHub #91 requests additional offcut/split guides (top/bottom, double spine, etc.).
+ * The current model supports at most two cutters for SINGLE_PAGE_CUT and one for
+ * TWO_PAGES. Extending that requires coordinated updates to serialization, this
+ * class, ImageView interaction, and downstream geometry consumers.
+ *
  * The page layout comprises the following:
  * \li A rectangular outline, possibly affine-transformed.
  * \li Layout type indicator.


### PR DESCRIPTION
Related to #91.

Adds an in-header note describing the coordinated work needed for additional split/offcut cutters (top/bottom, double spine, etc.). This does not implement the full feature set requested in the issue.