### PR TITLE
docs(output): clarify Output guides vs margins guides (#82, #95)

### DIFF
--- a/src/core/filters/output/ImageView.cpp
+++ b/src/core/filters/output/ImageView.cpp
@@ -25,6 +25,9 @@ ImageView::~ImageView() = default;
 
 void ImageView::paintEvent(QPaintEvent* event) {
   ImageViewBase::paintEvent(event);
+  // Output guides (GitHub #82): viewport-centered cross only. Page layout margins
+  // use draggable mm guides in page_layout/ImageView.cpp; expanding Output to the
+  // same behaviour needs a product decision once reporters confirm desired scope.
   if (ApplicationSettings::getInstance().isOutputShowGuidesEnabled()) {
     QPainter painter(viewport());
     painter.save();


### PR DESCRIPTION
Related to #82 and #95.

Adds a short developer-facing comment next to the Output guide paint path: the Output stage only draws a viewport-centered cross, while **Margins** (page layout) already has draggable mm guides. This matches the triage question posted on both issues.