### PR TITLE
feat(output): fill outside page box (#92)

### DIFF
--- a/src/core/filters/output/ColorCommonOptions.cpp
+++ b/src/core/filters/output/ColorCommonOptions.cpp
@@ -8,20 +8,22 @@
 namespace output {
 ColorCommonOptions::ColorCommonOptions()
     : m_fillOffcut(true),
+      m_fillOutsidePageBox(false),
       m_fillMargins(true),
       m_normalizeIllumination(false),
-      m_fillingColor(FILL_BACKGROUND),
       m_wienerCoef(0.0),
-      m_wienerWindowSize(5) {}
+      m_wienerWindowSize(5),
+      m_fillingColor(FILL_BACKGROUND) {}
 
 ColorCommonOptions::ColorCommonOptions(const QDomElement& el)
     : m_fillOffcut(el.attribute("fillOffcut") == "1"),
+      m_fillOutsidePageBox(el.attribute("fillOutsidePageBox") == "1"),
       m_fillMargins(el.attribute("fillMargins") == "1"),
       m_normalizeIllumination(el.attribute("normalizeIlluminationColor") == "1"),
-      m_fillingColor(parseFillingColor(el.attribute("fillingColor"))),
-      m_posterizationOptions(el.namedItem("posterization-options").toElement()),
       m_wienerCoef(el.attribute("wienerCoef").toDouble()),
-      m_wienerWindowSize(el.attribute("wienerWinSize").toInt()) {
+      m_wienerWindowSize(el.attribute("wienerWinSize").toInt()),
+      m_fillingColor(parseFillingColor(el.attribute("fillingColor"))),
+      m_posterizationOptions(el.namedItem("posterization-options").toElement()) {
   if (m_wienerCoef < 0.0 || m_wienerCoef > 1.0) {
     m_wienerCoef = 0.0;
   }
@@ -34,6 +36,7 @@ QDomElement ColorCommonOptions::toXml(QDomDocument& doc, const QString& name) co
   QDomElement el(doc.createElement(name));
   el.setAttribute("fillMargins", m_fillMargins ? "1" : "0");
   el.setAttribute("fillOffcut", m_fillOffcut ? "1" : "0");
+  el.setAttribute("fillOutsidePageBox", m_fillOutsidePageBox ? "1" : "0");
   el.setAttribute("normalizeIlluminationColor", m_normalizeIllumination ? "1" : "0");
   el.setAttribute("fillingColor", formatFillingColor(m_fillingColor));
   el.appendChild(m_posterizationOptions.toXml(doc, "posterization-options"));
@@ -44,7 +47,8 @@ QDomElement ColorCommonOptions::toXml(QDomDocument& doc, const QString& name) co
 
 bool ColorCommonOptions::operator==(const ColorCommonOptions& other) const {
   return (m_normalizeIllumination == other.m_normalizeIllumination) && (m_fillMargins == other.m_fillMargins)
-         && (m_fillOffcut == other.m_fillOffcut) && (m_fillingColor == other.m_fillingColor)
+         && (m_fillOffcut == other.m_fillOffcut) && (m_fillOutsidePageBox == other.m_fillOutsidePageBox)
+         && (m_fillingColor == other.m_fillingColor)
          && (m_posterizationOptions == other.m_posterizationOptions) && (m_wienerCoef == other.m_wienerCoef)
          && (m_wienerWindowSize == other.m_wienerWindowSize);
 }

--- a/src/core/filters/output/ColorCommonOptions.cpp
+++ b/src/core/filters/output/ColorCommonOptions.cpp
@@ -46,14 +46,10 @@ QDomElement ColorCommonOptions::toXml(QDomDocument& doc, const QString& name) co
 }
 
 bool ColorCommonOptions::operator==(const ColorCommonOptions& other) const {
-  return (m_normalizeIllumination == other.m_normalizeIllumination)
-         && (m_fillMargins == other.m_fillMargins)
-         && (m_fillOffcut == other.m_fillOffcut)
-         && (m_fillOutsidePageBox == other.m_fillOutsidePageBox)
-         && (m_fillingColor == other.m_fillingColor)
-         && (m_posterizationOptions == other.m_posterizationOptions)
-         && (m_wienerCoef == other.m_wienerCoef)
-         && (m_wienerWindowSize == other.m_wienerWindowSize);
+  return (m_normalizeIllumination == other.m_normalizeIllumination) && (m_fillMargins == other.m_fillMargins)
+         && (m_fillOffcut == other.m_fillOffcut) && (m_fillOutsidePageBox == other.m_fillOutsidePageBox)
+         && (m_fillingColor == other.m_fillingColor) && (m_posterizationOptions == other.m_posterizationOptions)
+         && (m_wienerCoef == other.m_wienerCoef) && (m_wienerWindowSize == other.m_wienerWindowSize);
 }
 
 bool ColorCommonOptions::operator!=(const ColorCommonOptions& other) const {

--- a/src/core/filters/output/ColorCommonOptions.cpp
+++ b/src/core/filters/output/ColorCommonOptions.cpp
@@ -46,10 +46,13 @@ QDomElement ColorCommonOptions::toXml(QDomDocument& doc, const QString& name) co
 }
 
 bool ColorCommonOptions::operator==(const ColorCommonOptions& other) const {
-  return (m_normalizeIllumination == other.m_normalizeIllumination) && (m_fillMargins == other.m_fillMargins)
-         && (m_fillOffcut == other.m_fillOffcut) && (m_fillOutsidePageBox == other.m_fillOutsidePageBox)
+  return (m_normalizeIllumination == other.m_normalizeIllumination)
+         && (m_fillMargins == other.m_fillMargins)
+         && (m_fillOffcut == other.m_fillOffcut)
+         && (m_fillOutsidePageBox == other.m_fillOutsidePageBox)
          && (m_fillingColor == other.m_fillingColor)
-         && (m_posterizationOptions == other.m_posterizationOptions) && (m_wienerCoef == other.m_wienerCoef)
+         && (m_posterizationOptions == other.m_posterizationOptions)
+         && (m_wienerCoef == other.m_wienerCoef)
          && (m_wienerWindowSize == other.m_wienerWindowSize);
 }
 

--- a/src/core/filters/output/ColorCommonOptions.h
+++ b/src/core/filters/output/ColorCommonOptions.h
@@ -60,6 +60,10 @@ class ColorCommonOptions {
 
   void setFillOffcut(bool fillOffcut);
 
+  bool fillOutsidePageBox() const;
+
+  void setFillOutsidePageBox(bool fillOutsidePageBox);
+
   bool fillMargins() const;
 
   void setFillMargins(bool val);
@@ -92,6 +96,7 @@ class ColorCommonOptions {
 
 
   bool m_fillOffcut;
+  bool m_fillOutsidePageBox;
   bool m_fillMargins;
   bool m_normalizeIllumination;
   double m_wienerCoef;
@@ -153,6 +158,14 @@ inline bool ColorCommonOptions::fillOffcut() const {
 
 inline void ColorCommonOptions::setFillOffcut(bool fillOffcut) {
   m_fillOffcut = fillOffcut;
+}
+
+inline bool ColorCommonOptions::fillOutsidePageBox() const {
+  return m_fillOutsidePageBox;
+}
+
+inline void ColorCommonOptions::setFillOutsidePageBox(bool fillOutsidePageBox) {
+  m_fillOutsidePageBox = fillOutsidePageBox;
 }
 
 inline bool ColorCommonOptions::PosterizationOptions::isEnabled() const {

--- a/src/core/filters/output/OptionsWidget.cpp
+++ b/src/core/filters/output/OptionsWidget.cpp
@@ -207,6 +207,26 @@ void OptionsWidget::fillMarginsToggled(const bool checked) {
 void OptionsWidget::fillOffcutToggled(const bool checked) {
   ColorCommonOptions colorCommonOptions(m_colorParams.colorCommonOptions());
   colorCommonOptions.setFillOffcut(checked);
+  if (checked) {
+    colorCommonOptions.setFillOutsidePageBox(false);
+    fillOutsidePageBoxCB->blockSignals(true);
+    fillOutsidePageBoxCB->setChecked(false);
+    fillOutsidePageBoxCB->blockSignals(false);
+  }
+  m_colorParams.setColorCommonOptions(colorCommonOptions);
+  m_settings->setColorParams(m_pageId, m_colorParams);
+  emit reloadRequested();
+}
+
+void OptionsWidget::fillOutsidePageBoxToggled(const bool checked) {
+  ColorCommonOptions colorCommonOptions(m_colorParams.colorCommonOptions());
+  colorCommonOptions.setFillOutsidePageBox(checked);
+  if (checked) {
+    colorCommonOptions.setFillOffcut(false);
+    fillOffcutCB->blockSignals(true);
+    fillOffcutCB->setChecked(false);
+    fillOffcutCB->blockSignals(false);
+  }
   m_colorParams.setColorCommonOptions(colorCommonOptions);
   m_settings->setColorParams(m_pageId, m_colorParams);
   emit reloadRequested();
@@ -595,6 +615,8 @@ void OptionsWidget::updateColorsDisplay() {
   fillMarginsCB->setVisible(true);
   fillOffcutCB->setChecked(colorCommonOptions.fillOffcut());
   fillOffcutCB->setVisible(true);
+  fillOutsidePageBoxCB->setChecked(colorCommonOptions.fillOutsidePageBox());
+  fillOutsidePageBoxCB->setVisible(true);
   equalizeIlluminationCB->setChecked(blackWhiteOptions.normalizeIllumination());
   equalizeIlluminationCB->setVisible(colorMode != COLOR_GRAYSCALE);
   equalizeIlluminationColorCB->setChecked(colorCommonOptions.normalizeIllumination());
@@ -951,6 +973,7 @@ void OptionsWidget::setupUiConnections() {
 
   CONNECT(fillMarginsCB, SIGNAL(clicked(bool)), this, SLOT(fillMarginsToggled(bool)));
   CONNECT(fillOffcutCB, SIGNAL(clicked(bool)), this, SLOT(fillOffcutToggled(bool)));
+  CONNECT(fillOutsidePageBoxCB, SIGNAL(clicked(bool)), this, SLOT(fillOutsidePageBoxToggled(bool)));
   CONNECT(equalizeIlluminationCB, SIGNAL(clicked(bool)), this, SLOT(equalizeIlluminationToggled(bool)));
   CONNECT(equalizeIlluminationColorCB, SIGNAL(clicked(bool)), this, SLOT(equalizeIlluminationColorToggled(bool)));
   CONNECT(savitzkyGolaySmoothingCB, SIGNAL(clicked(bool)), this, SLOT(savitzkyGolaySmoothingToggled(bool)));

--- a/src/core/filters/output/OptionsWidget.h
+++ b/src/core/filters/output/OptionsWidget.h
@@ -120,6 +120,8 @@ class OptionsWidget : public FilterOptionsWidget, private Ui::OptionsWidget {
 
   void fillOffcutToggled(bool checked);
 
+  void fillOutsidePageBoxToggled(bool checked);
+
   void equalizeIlluminationToggled(bool checked);
 
   void equalizeIlluminationColorToggled(bool checked);

--- a/src/core/filters/output/OptionsWidget.ui
+++ b/src/core/filters/output/OptionsWidget.ui
@@ -225,6 +225,16 @@
             </widget>
            </item>
            <item>
+            <widget class="QCheckBox" name="fillOutsidePageBoxCB">
+             <property name="toolTip">
+              <string>Fill the full output page rectangle with the background color outside the page content, instead of following offcut geometry.</string>
+             </property>
+             <property name="text">
+              <string>Fill outside page box</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QCheckBox" name="fillMarginsCB">
              <property name="text">
               <string>Fill margins</string>

--- a/src/core/filters/output/OutputGenerator.cpp
+++ b/src/core/filters/output/OutputGenerator.cpp
@@ -319,7 +319,9 @@ void OutputGenerator::Processor::initParams() {
 void OutputGenerator::Processor::calcAreas() {
   m_targetSize = m_outRect.size().expandedTo(QSize(1, 1));
 
-  if (m_renderParams.fillOffcut()) {
+  if (m_renderParams.fillOutsidePageBox()) {
+    m_preCropArea = QRectF(m_outRect);
+  } else if (m_renderParams.fillOffcut()) {
     m_preCropArea = m_xform.resultingPreCropArea();
   } else {
     const QPolygonF imageRectInOutputCs = m_xform.transform().map(m_xform.origRect());

--- a/src/core/filters/output/RenderParams.cpp
+++ b/src/core/filters/output/RenderParams.cpp
@@ -53,7 +53,9 @@ RenderParams::RenderParams(const ColorParams& colorParams, const SplittingOption
   if (colorCommonOptions.fillMargins()) {
     m_mask |= FILL_MARGINS;
   }
-  if (colorCommonOptions.fillOffcut()) {
+  if (colorCommonOptions.fillOutsidePageBox()) {
+    m_mask |= FILL_OUTSIDE_PAGE_BOX;
+  } else if (colorCommonOptions.fillOffcut()) {
     m_mask |= FILL_OFFCUT;
   }
   if (colorCommonOptions.normalizeIllumination()) {

--- a/src/core/filters/output/RenderParams.h
+++ b/src/core/filters/output/RenderParams.h
@@ -17,6 +17,8 @@ class RenderParams {
 
   bool fillOffcut() const;
 
+  bool fillOutsidePageBox() const;
+
   bool fillMargins() const;
 
   bool normalizeIllumination() const;
@@ -54,7 +56,8 @@ class RenderParams {
     ORIGINAL_BACKGROUND = 1 << 8,
     COLOR_SEGMENTATION = 1 << 9,
     POSTERIZE = 1 << 10,
-    FILL_OFFCUT = 1 << 11
+    FILL_OFFCUT = 1 << 11,
+    FILL_OUTSIDE_PAGE_BOX = 1 << 12
   };
 
   int m_mask;
@@ -111,6 +114,10 @@ inline bool RenderParams::posterize() const {
 
 inline bool RenderParams::fillOffcut() const {
   return (m_mask & FILL_OFFCUT) != 0;
+}
+
+inline bool RenderParams::fillOutsidePageBox() const {
+  return (m_mask & FILL_OUTSIDE_PAGE_BOX) != 0;
 }
 }  // namespace output
 #endif  // ifndef SCANTAILOR_OUTPUT_RENDERPARAMS_H_


### PR DESCRIPTION
Fixes #92.

- `ColorCommonOptions`: `fillOutsidePageBox` persisted in XML (default off).
- `RenderParams`: new flag; `fillOutsidePageBox` takes precedence over `fillOffcut` when building the mask.
- `OutputGenerator::calcAreas`: uses `QRectF(m_outRect)` for `m_preCropArea` when enabled.
- Output options: **Fill outside page box** checkbox, mutually exclusive with **Fill offcut** in the UI.

If this merges before #81, the follow-up dewarp-on-DPI PR should apply cleanly (touches only `dpiChanged`).