### PR TITLE
fix(output): freeze AUTO dewarp when changing output DPI (#81)

### DIFF
--- a/src/core/filters/output/OptionsWidget.cpp
+++ b/src/core/filters/output/OptionsWidget.cpp
@@ -262,6 +262,12 @@ void OptionsWidget::applyColorsButtonClicked() {
 
 void OptionsWidget::dpiChanged(const std::set<PageId>& pages, const Dpi& dpi) {
   for (const PageId& pageId : pages) {
+    Params params(m_settings->getParams(pageId));
+    if (params.dewarpingOptions().dewarpingMode() == AUTO) {
+      DewarpingOptions opt(params.dewarpingOptions());
+      opt.setDewarpingMode(MANUAL);
+      m_settings->setDewarpingOptions(pageId, opt);
+    }
     m_settings->setDpi(pageId, dpi);
   }
 


### PR DESCRIPTION
Fixes #81.

When the user applies a new output DPI via `dpiChanged`, pages still in **AUTO** dewarping are switched to **MANUAL** first so the existing distortion model is kept instead of being recomputed at the new resolution.