### PR TITLE
Linux releases: Qt AppImage bundling, .deb metadata; Flatpak docs (#64, #105)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,8 @@ jobs:
         run: |
           cd build-appimage
           export QMAKE=/usr/bin/qmake
-          ../linuxdeploy-x86_64.AppImage --appdir AppDir -e AppDir/usr/bin/scantailor --output appimage
+          # Bundle Qt platform plugins (e.g. xcb) via linuxdeploy-plugin-qt; same-dir discovery.
+          ../linuxdeploy-x86_64.AppImage --appdir AppDir --plugin qt -e AppDir/usr/bin/scantailor --output appimage
           OUT=$(ls -1 *.AppImage 2>/dev/null | head -1)
           mv "$OUT" "../scantailor-advanced-${{ github.ref_name }}-x86_64.AppImage"
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Go to [this repository](https://github.com/ScanTailor-Advanced/scantailor-libs-b
 
 **Application ID:** the manifest uses `org.scantailor.Advanced` so it does **not** replace the legacy `com.github._4lex4.*` Flatpak. Author docs: [for app authors](https://docs.flathub.org/docs/for-app-authors/).
 
+**Linux – GitHub Releases (.deb / AppImage, [issue #64](https://github.com/ScanTailor-Advanced/scantailor-advanced/issues/64)):** Version tags matching `v*` run [`.github/workflows/release.yml`](.github/workflows/release.yml), which produces a `.deb` ([`build-deb.sh`](build-deb.sh)) and an AppImage attached to the GitHub Release when the workflow is enabled. Report problems with those binaries in [issue #64](https://github.com/ScanTailor-Advanced/scantailor-advanced/issues/64).
+
 **Community examples / test data:** See also [scantailor-testing](https://github.com/ImageProcessing-ElectronicPublications/scantailor-testing) (community repository; issue [#43](https://github.com/ScanTailor-Advanced/scantailor-advanced/issues/43)).
 
 ## About this fork

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -58,13 +58,14 @@ Section: graphics
 Priority: optional
 Architecture: ${ARCH}
 Depends: ${DEPS}
-Maintainer: 4lex4 <4lex49@zoho.com>
+Maintainer: ScanTailor-Advanced <https://github.com/ScanTailor-Advanced/scantailor-advanced>
 Description: Interactive post-processing tool for scanned pages
  ScanTailor Advanced merges features from ScanTailor Featured and Enhanced,
  with improvements for page splitting, deskewing, content selection,
  margins, dewarping and output. Supports batch processing and multiple
  output formats.
 Homepage: https://github.com/ScanTailor-Advanced/scantailor-advanced
+Bugs: https://github.com/ScanTailor-Advanced/scantailor-advanced/issues
 EOF
 
 # Optional: refresh icon and desktop caches after install


### PR DESCRIPTION
## Summary

Addresses distribution follow-ups from **#64** (GitHub Release binaries) and **#105** (Flatpak documentation and manifest maintenance in this repo).

### #64

- **AppImage:** `.github/workflows/release.yml` downloaded `linuxdeploy-plugin-qt` but never ran it. The AppImage step now calls `linuxdeploy` with `--plugin qt` so Qt platform plugins (including `xcb`) are bundled, matching the failure mode described in the issue.
- **.deb metadata:** `build-deb.sh` now sets `Maintainer`, `Homepage`, and `Bugs` to this fork instead of the original upstream.

### #105

- **README:** Clarifies local `flatpak-builder` usage (KDE `5.15-23.08`), that Flathub still lists `com.github._4lex4.ScanTailor-Advanced`, and that a future Flathub listing for this fork is out of scope for this PR (tracked in #105).
- **Manifest:** `flatpak/org.scantailor.Advanced.json` uses KDE runtime `5.15-23.08` and drops redundant `base` / `base-version` entries that duplicated the SDK.

## Testing

- Not run: full AppImage build needs the release workflow or a matching local linuxdeploy run.
- `build-deb.sh` changes are metadata-only aside from existing dependency logic.

Feedback welcome on whether a tagged release test run should happen before merge.