### PR TITLE
fix Language select and deprecated thresholds

### DIFF
--- a/src/app/DefaultParamsDialog.cpp
+++ b/src/app/DefaultParamsDialog.cpp
@@ -50,8 +50,6 @@ DefaultParamsDialog::DefaultParamsDialog(QWidget* parent)
   thresholdMethodBox->addItem(tr("Wolf"), T_WOLF);
   thresholdMethodBox->addItem(tr("Bradley"), T_BRADLEY);
   thresholdMethodBox->addItem(tr("Grad"), T_GRAD);
-  thresholdMethodBox->addItem(tr("EdgePlus"), T_EDGEPLUS);
-  thresholdMethodBox->addItem(tr("BlurDiv"), T_BLURDIV);
   thresholdMethodBox->addItem(tr("EdgeDiv"), T_EDGEDIV);
 
   pictureShapeSelector->addItem(tr("Off"), OFF_SHAPE);
@@ -670,8 +668,7 @@ std::unique_ptr<DefaultParams> DefaultParamsDialog::buildParams() const {
   blackWhiteOptions.setBinarizationMethod(binarizationMethod);
   blackWhiteOptions.setThresholdAdjustment(thresholdSlider->value());
   blackWhiteOptions.setSauvolaCoef(sauvolaCoef->value());
-  if (binarizationMethod == T_SAUVOLA || binarizationMethod == T_BRADLEY || binarizationMethod == T_EDGEPLUS
-      || binarizationMethod == T_BLURDIV || binarizationMethod == T_EDGEDIV) {
+  if (binarizationMethod == T_SAUVOLA || binarizationMethod == T_BRADLEY || binarizationMethod == T_EDGEDIV) {
     blackWhiteOptions.setWindowSize(sauvolaWindowSize->value());
   } else if (binarizationMethod == T_WOLF || binarizationMethod == T_GRAD) {
     blackWhiteOptions.setWindowSize(wolfWindowSize->value());

--- a/src/core/Application.cpp
+++ b/src/core/Application.cpp
@@ -65,7 +65,7 @@ void Application::initTranslations() {
 #endif
   const QStringList translationDirs(QString::fromUtf8(TRANSLATION_DIRS).split(QChar(':'), opt));
 
-  const QStringList languageFileFilter("scantailor_*.qm");
+  const QStringList languageFileFilter("scantailor-advanced_*.qm");
   for (const QString& path : translationDirs) {
     QDir dir = (QDir::isAbsolutePath(path)) ? QDir(path) : QDir::cleanPath(applicationDirPath() + '/' + path);
     if (dir.exists()) {

--- a/src/core/filters/output/BlackWhiteOptions.cpp
+++ b/src/core/filters/output/BlackWhiteOptions.cpp
@@ -80,10 +80,6 @@ BinarizationMethod BlackWhiteOptions::parseBinarizationMethod(const QString& str
     return T_BRADLEY;
   } else if (str == "grad") {
     return T_GRAD;
-  } else if (str == "edgeplus") {
-    return T_EDGEPLUS;
-  } else if (str == "blurdiv") {
-    return T_BLURDIV;
   } else if (str == "edgediv") {
     return T_EDGEDIV;
   } else {
@@ -114,12 +110,6 @@ QString BlackWhiteOptions::formatBinarizationMethod(BinarizationMethod type) {
       break;
     case T_GRAD:
       str = "grad";
-      break;
-    case T_EDGEPLUS:
-      str = "edgeplus";
-      break;
-    case T_BLURDIV:
-      str = "blurdiv";
       break;
     case T_EDGEDIV:
       str = "edgediv";

--- a/src/core/filters/output/BlackWhiteOptions.h
+++ b/src/core/filters/output/BlackWhiteOptions.h
@@ -17,8 +17,6 @@ enum BinarizationMethod {
   T_WINDOW,
   T_BRADLEY,
   T_GRAD,
-  T_EDGEPLUS,
-  T_BLURDIV,
   T_EDGEDIV
 };
 

--- a/src/core/filters/output/OptionsWidget.cpp
+++ b/src/core/filters/output/OptionsWidget.cpp
@@ -46,8 +46,6 @@ OptionsWidget::OptionsWidget(std::shared_ptr<Settings> settings, const PageSelec
   thresholdMethodBox->addItem(tr("Window"), T_WINDOW);
   thresholdMethodBox->addItem(tr("Bradley"), T_BRADLEY);
   thresholdMethodBox->addItem(tr("Grad"), T_GRAD);
-  thresholdMethodBox->addItem(tr("EdgePlus"), T_EDGEPLUS);
-  thresholdMethodBox->addItem(tr("BlurDiv"), T_BLURDIV);
   thresholdMethodBox->addItem(tr("EdgeDiv"), T_EDGEDIV);
 
   fillingColorBox->addItem(tr("Background"), FILL_BACKGROUND);
@@ -63,10 +61,6 @@ OptionsWidget::OptionsWidget(std::shared_ptr<Settings> settings, const PageSelec
   QPointer<OptionsWidgetBinarization> bradleyOptionsWidgetBinarization
       = new OptionsWidgetBinarizationSauvola(m_settings);
   QPointer<OptionsWidgetBinarization> gradOptionsWidgetBinarization = new OptionsWidgetBinarizationWolf(m_settings);
-  QPointer<OptionsWidgetBinarization> edgeplusOptionsWidgetBinarization
-      = new OptionsWidgetBinarizationSauvola(m_settings);
-  QPointer<OptionsWidgetBinarization> blurdivOptionsWidgetBinarization
-      = new OptionsWidgetBinarizationSauvola(m_settings);
   QPointer<OptionsWidgetBinarization> edgedivOptionsWidgetBinarization
       = new OptionsWidgetBinarizationSauvola(m_settings);
 
@@ -80,8 +74,6 @@ OptionsWidget::OptionsWidget(std::shared_ptr<Settings> settings, const PageSelec
   addOptionsWidgetBinarization(windowOptionsWidgetBinarization);
   addOptionsWidgetBinarization(bradleyOptionsWidgetBinarization);
   addOptionsWidgetBinarization(gradOptionsWidgetBinarization);
-  addOptionsWidgetBinarization(edgeplusOptionsWidgetBinarization);
-  addOptionsWidgetBinarization(blurdivOptionsWidgetBinarization);
   addOptionsWidgetBinarization(edgedivOptionsWidgetBinarization);
   updateBinarizationOptionsDisplay(binarizationOptions->currentIndex());
 

--- a/src/core/filters/output/OutputGenerator.cpp
+++ b/src/core/filters/output/OutputGenerator.cpp
@@ -2374,22 +2374,6 @@ BinaryImage OutputGenerator::Processor::binarize(const QImage& image) const {
       binarized = binarizeGrad(image, windowsSize, lowerBound, upperBound, thresholdCoef, thresholdDelta);
       break;
     }
-    case T_EDGEPLUS: {
-      const double thresholdDelta = blackWhiteOptions.thresholdAdjustment();
-      const QSize windowsSize = QSize(blackWhiteOptions.getWindowSize(), blackWhiteOptions.getWindowSize());
-      const double thresholdCoef = blackWhiteOptions.getSauvolaCoef();
-
-      binarized = binarizeEdgeDiv(image, windowsSize, thresholdCoef, 0.0, thresholdDelta);
-      break;
-    }
-    case T_BLURDIV: {
-      const double thresholdDelta = blackWhiteOptions.thresholdAdjustment();
-      const QSize windowsSize = QSize(blackWhiteOptions.getWindowSize(), blackWhiteOptions.getWindowSize());
-      const double thresholdCoef = blackWhiteOptions.getSauvolaCoef();
-
-      binarized = binarizeEdgeDiv(image, windowsSize, 0.0, thresholdCoef, thresholdDelta);
-      break;
-    }
     case T_EDGEDIV: {
       const double thresholdDelta = blackWhiteOptions.thresholdAdjustment();
       const QSize windowsSize = QSize(blackWhiteOptions.getWindowSize(), blackWhiteOptions.getWindowSize());


### PR DESCRIPTION
Fine-tuning #146 .

Tuning #150 :

:warning: **Deprecated**.

| Threshold | Radius | Coef | Status |
| --- | --- | --- | --- |
| EdgePlus {kep,0}| 5 | 0.75 | deprecated, remove |
| BlurDiv {0,kdb}| 5 | 0.75 | deprecated, remove |

☑️ **Workers**.

| Threshold | Radius | Coef | Status |
| --- | --- | --- | --- |
| Sauvola| 100 | 0.34 | founder of the "Means" series |
| Wolf | 100 | 0.30 | current of the "Means" series |
| Fox | 100 | 0.30 | optimize resource |
| Window {without `*3.0`}| 50 | 1.00 | ☑️  best of the "Means" series |
| Bradley | 100 | 0.15 | simple of the "Means" series |
| Grad | 15 | 0.75 | ☑️  best of the "Hybrid" series |
| EdgeDiv {kep,kdb}| 5 | 0.75 | ☑️ best of the "Prefilter" series |


`ws = Radius + 1 + Radius; Window_Size = QSize(ws,ws);` (a derived quantity for using integral images instead of direct filtering).
